### PR TITLE
[codex] Speed up HTTP hot paths and pin DHI PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,54 @@
 # NanoAPI
 
-NanoAPI is a pure Zig HTTP API library with FastAPI-style behavior as a parity
-target. It reuses
-`turboapi-core` for the hot router and HTTP helpers, then layers a Zig API over
-it with familiar names like `NanoAPI`, `APIRouter`, `Request`, `Response`,
-`JSONResponse`, `HTTPException`, `Query`, `Path`, and `status`.
+NanoAPI is a pure Zig HTTP API framework with FastAPI-inspired ergonomics:
+typed route parameters, response helpers, OpenAPI metadata, streaming responses,
+and a small native HTTP/1.1 server.
 
-This is the first implementation slice: route registration, route inclusion,
-typed path/query parsing, response helpers, security scheme metadata, background
-tasks, and OpenAPI 3.1 JSON generation.
+The hot routing path is backed by `turboapi-core`, while validation primitives
+come from `dhi`. The current dependency pin uses the `dhi` performance branch
+from `justrach/dhi#54`; switch it back to `dhi` main once that PR lands.
 
-## Example
+## Quick Start
 
 ```zig
 const std = @import("std");
 const nano = @import("nanoapi");
 
-fn getUser(req: *nano.Request) !nano.Response {
-    const user_id = req.pathInt("user_id") orelse 0;
-    const body = try std.fmt.allocPrint(
-        req.allocator,
-        "{{\"user_id\":{d}}}",
-        .{user_id},
-    );
-    return nano.Response.fromOwnedBody(req.allocator, body, .{
-        .media_type = "application/json",
-    });
+fn root(req: *nano.Request) !nano.Response {
+    return nano.JSONResponse.static(req.allocator, "{\"ok\":true}", .{});
 }
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    const allocator = std.heap.smp_allocator;
     var app = try nano.NanoAPI.init(allocator, .{
-        .title = "Example",
+        .title = "Example API",
         .version = "1.0.0",
     });
     defer app.deinit();
 
-    const parameters = [_]nano.Parameter{
-        nano.Path("user_id", .integer, .{}),
-        nano.Query("verbose", .boolean, .{ .required = false }),
-    };
+    try app.get("/", root, .{ .tags = &.{"health"} });
 
-    try app.get("/users/{user_id}", getUser, .{
-        .tags = &.{"users"},
-        .parameters = &parameters,
+    try app.listenAndServe(allocator, .{
+        .host = .{ 127, 0, 0, 1 },
+        .port = 8080,
     });
 }
 ```
 
-## Type-Safe Routes
+## Typed Routes
+
+Route handlers can parse path and query values into Zig structs. Defaults and
+optional fields work naturally, and DHI-backed validation runs only when a struct
+uses validation naming conventions such as `email`, `*_email`, or `*_ne`.
 
 ```zig
-const PathParams = struct { user_id: i64 };
-const QueryParams = struct { verbose: bool = false };
+const PathParams = struct {
+    user_id: i64,
+};
+
+const QueryParams = struct {
+    verbose: bool = false,
+};
 
 fn getUser(ctx: nano.typed.Context(PathParams, QueryParams)) !nano.Response {
     const body = try std.fmt.allocPrint(
@@ -68,35 +64,10 @@ fn getUser(ctx: nano.typed.Context(PathParams, QueryParams)) !nano.Response {
 try app.getTyped(PathParams, QueryParams, "/users/{user_id}", getUser, .{});
 ```
 
-## Build
+## Responses
 
-```bash
-zig build test
-zig build -Doptimize=ReleaseFast bench -- 10000000
-zig build -Doptimize=ReleaseFast http-server -- 8080
-```
-
-The package depends on `turboapi_core`, pinned in `build.zig.zon`.
-It also depends on `dhi` for Zig-native validation primitives and model-style
-descriptors.
-
-## HTTP Server
-
-```zig
-try app.listenAndServe(std.heap.smp_allocator, .{
-    .host = .{ 127, 0, 0, 1 },
-    .port = 8080,
-});
-```
-
-The initial server is a compact HTTP/1.1 implementation with keep-alive and a
-thread per accepted connection. It is enough for local `wrk` benchmarking while
-the runtime evolves.
-
-## Streaming, Files, and SSE
-
-Responses now keep the fast byte-body path while also supporting streamed files
-and chunked stream writers:
+NanoAPI includes response helpers for JSON, text, HTML, redirects, file bodies,
+chunked streams, and server-sent events.
 
 ```zig
 fn events(ctx: *nano.StreamContext) !void {
@@ -113,20 +84,70 @@ fn download(req: *nano.Request) !nano.Response {
 }
 ```
 
-WebSockets should be a separate upgrade route that takes over the accepted
-connection instead of returning a normal `Response`. QUIC/HTTP3 should be a
-separate transport backend sharing `NanoAPI.handle`; it is not a small patch to
-the HTTP/1.1 TCP loop.
+## Server Runtime
 
-## FastAPI Parity Roadmap
+The built-in server is a compact HTTP/1.1 implementation with keep-alive. The
+default runtime is `.auto`: on macOS and BSD targets it uses the kqueue event
+loop; elsewhere it falls back to thread-per-connection until another event
+backend is added.
 
-- Done: routing decorators as Zig methods, routers with prefixes, typed
-  path/query structs, response classes, cookies, status constants, basic
-  security helpers, OpenAPI, dispatch benchmark, native HTTP server loop,
-  streamed files, chunked streaming responses, SSE helpers, DHI-backed typed
-  validation.
-- Next: dependency injection execution, middleware stack, file uploads/forms,
-  WebSocket upgrade routes, optional HTTP3/QUIC transport.
+The hot response path avoids unnecessary allocations and omits redundant
+`Connection: keep-alive` headers for HTTP/1.1 responses.
+
+```zig
+try app.listenAndServe(std.heap.smp_allocator, .{
+    .host = .{ 127, 0, 0, 1 },
+    .port = 8080,
+    .runtime = .auto,
+});
+```
+
+## Build And Bench
+
+```bash
+zig build test
+zig build -Doptimize=ReleaseFast bench -- 10000000
+zig build -Doptimize=ReleaseFast http-server -- 8080
+```
+
+Example local `wrk` profile:
+
+```bash
+wrk -t4 -c64 -d10s --latency http://127.0.0.1:8080/
+wrk -t4 -c64 -d10s --latency 'http://127.0.0.1:8080/users/42?verbose=true'
+```
+
+Recent local comparison against `karlseguin/http.zig` using equivalent handlers:
+
+| Route | NanoAPI | http.zig |
+| --- | ---: | ---: |
+| `/` | ~168k req/s | ~166k req/s |
+| `/users/42?verbose=true` | ~167k req/s | ~166k req/s |
+
+Treat these numbers as directional; they vary by machine, thermal state, Zig
+build, and background load.
+
+## Feature Shape
+
+Done:
+
+- `NanoAPI` and `APIRouter`
+- typed path/query structs
+- JSON, text, HTML, redirect, file, stream, and SSE responses
+- cookie helpers
+- status constants
+- security metadata helpers
+- OpenAPI 3.1 JSON generation
+- DHI-backed typed validation
+- native HTTP/1.1 server and dispatch benchmarks
+
+Next:
+
+- middleware stack
+- dependency injection execution
+- file uploads and form parsing
+- WebSocket upgrade routes
+- optional HTTP/3 and QUIC transport sharing the same app/router layer
 
 ## License
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,8 +8,8 @@
             .hash = "turboapi_core-0.1.0-DjdHgmaTAAC5tl8N6M66vDdnSSS6CPbk6QwhlCLH--PZ",
         },
         .dhi = .{
-            .url = "git+https://github.com/justrach/dhi.git?ref=main#4f607331c51b2ec974310e8cb5d40cf61a8ab6b1",
-            .hash = "dhi-0.1.0-Fz3bn1CFAwDexo2jviNTcIrQeJZ5TM6fCcHcdPIO2wK1",
+            .url = "git+https://github.com/justrach/dhi.git?ref=codex/dhi-fast-validators#ba44a5d04ff0c67dd4d9975963e162c77b13f496",
+            .hash = "dhi-0.1.0-Fz3bn4aKAwDis5C7d-B58ZIR5zy9P38M1einoxEm5IgU",
         },
     },
     .paths = .{""},

--- a/src/request.zig
+++ b/src/request.zig
@@ -34,6 +34,26 @@ pub const Request = struct {
         };
     }
 
+    pub fn initParts(
+        allocator: std.mem.Allocator,
+        method: []const u8,
+        target: []const u8,
+        path: []const u8,
+        query_string: []const u8,
+        headers: []const HeaderPair,
+        body: []const u8,
+    ) Request {
+        return .{
+            .allocator = allocator,
+            .method = method,
+            .target = target,
+            .path = path,
+            .query_string = query_string,
+            .headers = headers,
+            .body = body,
+        };
+    }
+
     pub fn setPathParams(self: *Request, params: *const core.RouteParams) void {
         self.path_params = params;
     }

--- a/src/response.zig
+++ b/src/response.zig
@@ -79,23 +79,16 @@ pub const Response = struct {
         var body_owned = true;
         errdefer if (body_owned) allocator.free(body);
 
-        const media_type = if (options.media_type) |m| try allocator.dupe(u8, m) else null;
-        var media_owned = true;
-        errdefer if (media_owned) {
-            if (media_type) |m| allocator.free(m);
-        };
-
         var res = Response{
             .allocator = allocator,
             .status_code = options.status_code,
-            .media_type = media_type,
-            .media_type_owned = media_type != null,
+            .media_type = options.media_type,
+            .media_type_owned = false,
             .body = body,
             .body_owned = true,
             .body_kind = .bytes,
         };
         body_owned = false;
-        media_owned = false;
         errdefer res.deinit();
         for (options.headers) |h| {
             try res.addHeader(h.name, h.value);
@@ -132,23 +125,17 @@ pub const Response = struct {
     ) !Response {
         const owned_path = try allocator.dupe(u8, path);
         errdefer allocator.free(owned_path);
-        const media_type = if (options.media_type) |m| try allocator.dupe(u8, m) else null;
-        var media_owned = true;
-        errdefer if (media_owned) {
-            if (media_type) |m| allocator.free(m);
-        };
 
         var res = Response{
             .allocator = allocator,
             .status_code = options.status_code,
-            .media_type = media_type,
-            .media_type_owned = media_type != null,
+            .media_type = options.media_type,
+            .media_type_owned = false,
             .body_kind = .file,
             .file_path = owned_path,
             .file_path_owned = true,
             .file_size = size,
         };
-        media_owned = false;
         errdefer res.deinit();
         for (options.headers) |h| {
             try res.addHeader(h.name, h.value);
@@ -161,21 +148,14 @@ pub const Response = struct {
         writer: StreamWriteFn,
         options: ResponseOptions,
     ) !Response {
-        const media_type = if (options.media_type) |m| try allocator.dupe(u8, m) else null;
-        var media_owned = true;
-        errdefer if (media_owned) {
-            if (media_type) |m| allocator.free(m);
-        };
-
         var res = Response{
             .allocator = allocator,
             .status_code = options.status_code,
-            .media_type = media_type,
-            .media_type_owned = media_type != null,
+            .media_type = options.media_type,
+            .media_type_owned = false,
             .body_kind = .stream,
             .stream_writer = writer,
         };
-        media_owned = false;
         errdefer res.deinit();
         for (options.headers) |h| {
             try res.addHeader(h.name, h.value);

--- a/src/routing.zig
+++ b/src/routing.zig
@@ -34,12 +34,20 @@ pub const RouteDefinition = struct {
     }
 };
 
+const ExactRoute = struct {
+    method: []const u8,
+    path: []const u8,
+    index: usize,
+};
+
 pub const APIRouter = struct {
     allocator: std.mem.Allocator,
     prefix: []const u8,
     tags: []const []const u8,
     core_router: core.Router,
     routes_list: std.ArrayList(RouteDefinition) = .empty,
+    exact_routes: std.ArrayList(ExactRoute) = .empty,
+    root_get_index: ?usize = null,
 
     pub fn init(allocator: std.mem.Allocator, router_options: RouterOptions) !APIRouter {
         const prefix = try allocator.dupe(u8, router_options.prefix);
@@ -57,6 +65,7 @@ pub const APIRouter = struct {
 
     pub fn deinit(self: *APIRouter) void {
         for (self.routes_list.items) |*route_def| route_def.deinit(self.allocator);
+        self.exact_routes.deinit(self.allocator);
         self.routes_list.deinit(self.allocator);
         self.core_router.deinit();
         freeStringList(self.allocator, self.tags);
@@ -123,6 +132,18 @@ pub const APIRouter = struct {
     }
 
     pub fn handle(self: *APIRouter, req: *request.Request) !response.Response {
+        if (self.root_get_index) |index| {
+            if (req.path.len == 1 and req.path[0] == '/' and std.mem.eql(u8, req.method, "GET")) {
+                return self.routes_list.items[index].handler(req);
+            }
+        }
+
+        for (self.exact_routes.items) |exact| {
+            if (std.mem.eql(u8, req.method, exact.method) and std.mem.eql(u8, req.path, exact.path)) {
+                return self.routes_list.items[exact.index].handler(req);
+            }
+        }
+
         var matched = self.core_router.findRoute(req.method, req.path) orelse {
             return response.jsonError(req.allocator, status.HTTP_404_NOT_FOUND, "Not Found", &.{});
         };
@@ -174,9 +195,23 @@ pub const APIRouter = struct {
         try self.routes_list.append(self.allocator, route_def);
         errdefer _ = self.routes_list.pop();
 
+        if (std.mem.eql(u8, owned_method, "GET") and std.mem.eql(u8, full_path, "/")) {
+            self.root_get_index = index;
+        } else if (isExactPath(full_path)) {
+            try self.exact_routes.append(self.allocator, .{
+                .method = owned_method,
+                .path = full_path,
+                .index = index,
+            });
+        }
+
         try self.core_router.addRoute(method, full_path, key);
     }
 };
+
+fn isExactPath(path: []const u8) bool {
+    return std.mem.indexOfAny(u8, path, "{*") == null;
+}
 
 fn routeKeyForIndex(allocator: std.mem.Allocator, index: usize) ![]u8 {
     const key = try allocator.alloc(u8, @sizeOf(usize));

--- a/src/server.zig
+++ b/src/server.zig
@@ -186,10 +186,12 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
         };
         defer body.deinit(server.allocator);
 
-        var req = request.Request.init(
+        var req = request.Request.initParts(
             server.allocator,
             parsed.method,
             parsed.target,
+            parsed.path,
+            parsed.query_string,
             parsed.headers,
             body.bytes,
         );
@@ -251,10 +253,12 @@ const Connection = struct {
         };
         defer body.deinit(self.server.allocator);
 
-        var req = request.Request.init(
+        var req = request.Request.initParts(
             self.server.allocator,
             parsed.method,
             parsed.target,
+            parsed.path,
+            parsed.query_string,
             parsed.headers,
             body.bytes,
         );
@@ -273,6 +277,8 @@ const Connection = struct {
 const ParsedRequest = struct {
     method: []const u8,
     target: []const u8,
+    path: []const u8,
+    query_string: []const u8,
     headers: []const request.HeaderPair,
     body: []const u8,
     content_length: usize,
@@ -293,6 +299,9 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
     const method = first_line[0..method_end];
     const target = first_line[method_end + 1 .. version_start];
     const version = first_line[version_start + 1 ..];
+    const query_start = std.mem.indexOfScalar(u8, target, '?');
+    const path = if (query_start) |idx| target[0..idx] else target;
+    const query_string = if (query_start) |idx| target[idx + 1 ..] else "";
 
     var keep_alive = std.mem.eql(u8, version, "HTTP/1.1");
     var header_count: usize = 0;
@@ -321,6 +330,8 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
     return .{
         .method = method,
         .target = target,
+        .path = path,
+        .query_string = query_string,
         .headers = headers_buf[0..header_count],
         .body = if (body.len > content_length) body[0..content_length] else body,
         .content_length = content_length,
@@ -453,6 +464,10 @@ fn recvOnce(fd: c.fd_t, buf: []u8) !usize {
 }
 
 fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, head_only: bool) !void {
+    if (canUseFastJsonBytes(res, keep_alive, head_only)) {
+        return sendFastJsonBytes(fd, res.body);
+    }
+
     var sender = BufferedSender.init(fd);
 
     var scratch: [256]u8 = undefined;
@@ -521,6 +536,63 @@ fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, hea
             try sendAll(fd, "0\r\n\r\n");
         },
     }
+}
+
+fn canUseFastJsonBytes(res: *const response.Response, keep_alive: bool, head_only: bool) bool {
+    if (!keep_alive or head_only) return false;
+    if (res.status_code != status.HTTP_200_OK) return false;
+    if (res.body_kind != .bytes) return false;
+    if (res.headers.items.len != 0) return false;
+    const media_type = res.media_type orelse return false;
+    return std.mem.eql(u8, media_type, "application/json");
+}
+
+fn sendFastJsonBytes(fd: c.fd_t, body: []const u8) !void {
+    var buf: [1024]u8 = undefined;
+    var len: usize = 0;
+
+    const prefix = "HTTP/1.1 200 OK\r\nContent-Length: ";
+    const middle = "\r\nConnection: keep-alive\r\nContent-Type: application/json\r\n\r\n";
+    const max_len = prefix.len + 20 + middle.len + body.len;
+    if (max_len > buf.len) {
+        var sender = BufferedSender.init(fd);
+        try sender.append(prefix);
+        len = appendDecimal(buf[0..], body.len);
+        try sender.append(buf[0..len]);
+        try sender.append(middle);
+        try sender.append(body);
+        return sender.flush();
+    }
+
+    @memcpy(buf[len..][0..prefix.len], prefix);
+    len += prefix.len;
+    len += appendDecimal(buf[len..], body.len);
+    @memcpy(buf[len..][0..middle.len], middle);
+    len += middle.len;
+    @memcpy(buf[len..][0..body.len], body);
+    len += body.len;
+
+    try sendAll(fd, buf[0..len]);
+}
+
+fn appendDecimal(out: []u8, value: usize) usize {
+    if (value == 0) {
+        out[0] = '0';
+        return 1;
+    }
+
+    var tmp: [20]u8 = undefined;
+    var n = value;
+    var count: usize = 0;
+    while (n > 0) : (count += 1) {
+        tmp[count] = @intCast('0' + (n % 10));
+        n /= 10;
+    }
+
+    for (0..count) |i| {
+        out[i] = tmp[count - 1 - i];
+    }
+    return count;
 }
 
 fn sendFileBody(fd: c.fd_t, path: []const u8, file_size: u64) !void {

--- a/src/server.zig
+++ b/src/server.zig
@@ -17,7 +17,7 @@ pub const Options = struct {
     backlog: c_uint = 1024,
     read_buffer_size: usize = 16 * 1024,
     max_headers: usize = 64,
-    runtime: Runtime = .thread_per_connection,
+    runtime: Runtime = .auto,
 };
 
 pub const Runtime = enum {
@@ -202,7 +202,7 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
         };
         defer res.deinit();
 
-        sendResponse(fd, &res, parsed.keep_alive, std.mem.eql(u8, parsed.method, "HEAD")) catch return;
+        sendResponse(fd, &res, parsed.keep_alive, parsed.send_keep_alive_header, std.mem.eql(u8, parsed.method, "HEAD")) catch return;
         if (!parsed.keep_alive) return;
     }
 }
@@ -269,7 +269,7 @@ const Connection = struct {
         };
         defer res.deinit();
 
-        sendResponse(self.fd, &res, parsed.keep_alive, std.mem.eql(u8, parsed.method, "HEAD")) catch return false;
+        sendResponse(self.fd, &res, parsed.keep_alive, parsed.send_keep_alive_header, std.mem.eql(u8, parsed.method, "HEAD")) catch return false;
         return parsed.keep_alive;
     }
 };
@@ -283,45 +283,66 @@ const ParsedRequest = struct {
     body: []const u8,
     content_length: usize,
     keep_alive: bool,
+    send_keep_alive_header: bool,
 };
 
 pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !ParsedRequest {
-    const header_end = std.mem.indexOf(u8, buf, "\r\n\r\n") orelse return error.IncompleteRequestHead;
-    const head = buf[0..header_end];
-    const body = buf[header_end + 4 ..];
+    const method_end = std.mem.indexOfScalar(u8, buf, ' ') orelse return error.IncompleteRequestHead;
+    const target_start = method_end + 1;
+    const target_end = std.mem.indexOfScalarPos(u8, buf, target_start, ' ') orelse return error.InvalidRequestLine;
+    const version_start = target_end + 1;
+    const first_line_end = std.mem.indexOfPos(u8, buf, version_start, "\r\n") orelse return error.IncompleteRequestHead;
 
-    const first_line_end = std.mem.indexOf(u8, head, "\r\n") orelse return error.InvalidRequestLine;
-    const first_line = head[0..first_line_end];
-    const method_end = std.mem.indexOfScalar(u8, first_line, ' ') orelse return error.InvalidRequestLine;
-    const version_start = std.mem.lastIndexOfScalar(u8, first_line, ' ') orelse return error.InvalidRequestLine;
-    if (version_start <= method_end) return error.InvalidRequestLine;
-
-    const method = first_line[0..method_end];
-    const target = first_line[method_end + 1 .. version_start];
-    const version = first_line[version_start + 1 ..];
+    const method = buf[0..method_end];
+    const target = buf[target_start..target_end];
+    const version = buf[version_start..first_line_end];
     const query_start = std.mem.indexOfScalar(u8, target, '?');
     const path = if (query_start) |idx| target[0..idx] else target;
     const query_string = if (query_start) |idx| target[idx + 1 ..] else "";
 
     var keep_alive = std.mem.eql(u8, version, "HTTP/1.1");
+    var send_keep_alive_header = false;
     var header_count: usize = 0;
     var content_length: usize = 0;
+    var pos = first_line_end + 2;
+    var body: []const u8 = "";
 
-    var lines = std.mem.splitSequence(u8, head[first_line_end + 2 ..], "\r\n");
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
+    while (true) {
+        if (pos + 1 >= buf.len) return error.IncompleteRequestHead;
+        if (buf[pos] == '\r' and buf[pos + 1] == '\n') {
+            body = buf[pos + 2 ..];
+            break;
+        }
         if (header_count >= headers_buf.len) return error.TooManyHeaders;
 
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse return error.InvalidHeader;
-        const name = std.mem.trim(u8, line[0..colon], " \t");
-        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        const line_start = pos;
+        var colon: ?usize = null;
+        while (true) : (pos += 1) {
+            if (pos + 1 >= buf.len) return error.IncompleteRequestHead;
+            if (buf[pos] == ':' and colon == null) colon = pos;
+            if (buf[pos] == '\r') {
+                if (buf[pos + 1] != '\n') return error.InvalidHeader;
+                break;
+            }
+        }
+
+        const line_end = pos;
+        pos += 2;
+        const colon_pos = colon orelse return error.InvalidHeader;
+        if (colon_pos >= line_end) return error.InvalidHeader;
+
+        const name = trimHeaderWhitespace(buf[line_start..colon_pos]);
+        const value = trimHeaderWhitespace(buf[colon_pos + 1 .. line_end]);
 
         headers_buf[header_count] = .{ .name = name, .value = value };
         header_count += 1;
 
         if (std.ascii.eqlIgnoreCase(name, "connection")) {
             if (std.ascii.eqlIgnoreCase(value, "close")) keep_alive = false;
-            if (std.ascii.eqlIgnoreCase(value, "keep-alive")) keep_alive = true;
+            if (std.ascii.eqlIgnoreCase(value, "keep-alive")) {
+                keep_alive = true;
+                send_keep_alive_header = !std.mem.eql(u8, version, "HTTP/1.1");
+            }
         } else if (std.ascii.eqlIgnoreCase(name, "content-length")) {
             content_length = std.fmt.parseInt(usize, value, 10) catch return error.InvalidHeader;
         }
@@ -336,7 +357,16 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
         .body = if (body.len > content_length) body[0..content_length] else body,
         .content_length = content_length,
         .keep_alive = keep_alive,
+        .send_keep_alive_header = send_keep_alive_header,
     };
+}
+
+fn trimHeaderWhitespace(value: []const u8) []const u8 {
+    var start: usize = 0;
+    var end = value.len;
+    while (start < end and (value[start] == ' ' or value[start] == '\t')) : (start += 1) {}
+    while (end > start and (value[end - 1] == ' ' or value[end - 1] == '\t')) : (end -= 1) {}
+    return value[start..end];
 }
 
 const BodyBuffer = struct {
@@ -463,8 +493,8 @@ fn recvOnce(fd: c.fd_t, buf: []u8) !usize {
     }
 }
 
-fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, head_only: bool) !void {
-    if (canUseFastJsonBytes(res, keep_alive, head_only)) {
+fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, send_keep_alive_header: bool, head_only: bool) !void {
+    if (canUseFastJsonBytes(res, keep_alive, send_keep_alive_header, head_only)) {
         return sendFastJsonBytes(fd, res.body);
     }
 
@@ -489,7 +519,11 @@ fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, hea
         try sender.print(&scratch, "Content-Length: {d}\r\n", .{content_length});
     }
 
-    try sender.append(if (keep_alive) "Connection: keep-alive\r\n" else "Connection: close\r\n");
+    if (!keep_alive) {
+        try sender.append("Connection: close\r\n");
+    } else if (send_keep_alive_header) {
+        try sender.append("Connection: keep-alive\r\n");
+    }
 
     var has_content_type = false;
     for (res.headers.items) |header| {
@@ -538,8 +572,8 @@ fn sendResponse(fd: c.fd_t, res: *const response.Response, keep_alive: bool, hea
     }
 }
 
-fn canUseFastJsonBytes(res: *const response.Response, keep_alive: bool, head_only: bool) bool {
-    if (!keep_alive or head_only) return false;
+fn canUseFastJsonBytes(res: *const response.Response, keep_alive: bool, send_keep_alive_header: bool, head_only: bool) bool {
+    if (!keep_alive or send_keep_alive_header or head_only) return false;
     if (res.status_code != status.HTTP_200_OK) return false;
     if (res.body_kind != .bytes) return false;
     if (res.headers.items.len != 0) return false;
@@ -552,7 +586,7 @@ fn sendFastJsonBytes(fd: c.fd_t, body: []const u8) !void {
     var len: usize = 0;
 
     const prefix = "HTTP/1.1 200 OK\r\nContent-Length: ";
-    const middle = "\r\nConnection: keep-alive\r\nContent-Type: application/json\r\n\r\n";
+    const middle = "\r\nContent-Type: application/json\r\n\r\n";
     const max_len = prefix.len + 20 + middle.len + body.len;
     if (max_len > buf.len) {
         var sender = BufferedSender.init(fd);
@@ -712,9 +746,21 @@ test "parse HTTP request head" {
     try std.testing.expectEqualStrings("GET", parsed.method);
     try std.testing.expectEqualStrings("/users/42?verbose=true", parsed.target);
     try std.testing.expect(parsed.keep_alive);
+    try std.testing.expect(!parsed.send_keep_alive_header);
     try std.testing.expectEqual(@as(usize, 2), parsed.headers.len);
     try std.testing.expectEqualStrings("Host", parsed.headers[0].name);
     try std.testing.expectEqualStrings("localhost", parsed.headers[0].value);
+}
+
+test "parse HTTP/1.0 explicit keep-alive" {
+    var headers: [8]request.HeaderPair = undefined;
+    const parsed = try parseRequestHead(
+        "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n",
+        &headers,
+    );
+
+    try std.testing.expect(parsed.keep_alive);
+    try std.testing.expect(parsed.send_keep_alive_header);
 }
 
 test "parse HTTP request content length" {

--- a/src/typed.zig
+++ b/src/typed.zig
@@ -143,7 +143,9 @@ fn parseStruct(comptime T: type, req: *const request.Request, comptime location:
         }
     }
 
-    try validateParsed(T, result, req.allocator);
+    if (comptime needsDhiValidation(T)) {
+        try validateParsed(T, result, req.allocator);
+    }
     return result;
 }
 
@@ -193,6 +195,8 @@ fn parseValue(comptime T: type, raw: []const u8) ParseError!T {
 }
 
 fn parseBool(raw: []const u8) ParseError!bool {
+    if (std.mem.eql(u8, raw, "true") or std.mem.eql(u8, raw, "1")) return true;
+    if (std.mem.eql(u8, raw, "false") or std.mem.eql(u8, raw, "0")) return false;
     if (std.ascii.eqlIgnoreCase(raw, "true") or
         std.mem.eql(u8, raw, "1") or
         std.ascii.eqlIgnoreCase(raw, "on") or
@@ -236,6 +240,14 @@ fn schemaType(comptime T: type) meta.SchemaType {
 
 fn isOptional(comptime T: type) bool {
     return @typeInfo(T) == .optional;
+}
+
+fn needsDhiValidation(comptime T: type) bool {
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (std.mem.endsWith(u8, field.name, "_ne")) return true;
+        if (std.mem.eql(u8, field.name, "email") or std.mem.endsWith(u8, field.name, "_email")) return true;
+    }
+    return false;
 }
 
 fn assertStruct(comptime T: type) void {


### PR DESCRIPTION
## Summary

- Pins NanoAPI to the DHI performance branch from justrach/dhi#54 for validation testing.
- Avoids reparsing request targets by threading parsed path/query slices into `Request`.
- Skips DHI struct validation when typed route structs do not use DHI naming conventions.
- Adds a fast response write path for common 200 JSON byte responses.
- Omits redundant `Connection: keep-alive` on HTTP/1.1 responses, matching http.zig's leaner response shape while still preserving explicit HTTP/1.0 keep-alive.
- Defaults the server runtime to `.auto`, enabling the kqueue event loop on macOS/BSD targets.
- Adds exact-route dispatch caching plus a dedicated `GET /` fast slot before falling through to turboapi-core param routing.
- Uses a single-pass request-head parser to avoid rescanning request buffers.

## Benchmark notes

Local `wrk -t4 -c64 -d10s --latency` comparison against `karlseguin/http.zig` using equivalent `/` and `/users/:user_id` handlers:

| Route | NanoAPI latest | http.zig fresh rerun |
| --- | ---: | ---: |
| `/` | 167,899 req/s | 165,564 req/s |
| `/users/42?verbose=true` | 167,393 req/s | 166,131 req/s |

These runs are close enough that there is normal local noise, but NanoAPI is now at parity/slightly ahead on this two-route HTTP/1.1 keep-alive benchmark.

## Validation

- `zig build test --summary all` (12/12 tests passed)
- `zig build -Doptimize=ReleaseFast bench --summary all`
- Built and ran `zig build -Doptimize=ReleaseFast http-server -- 8080` for `wrk` benchmarking
- `git diff --check`

## Follow-up

After justrach/dhi#54 lands, this dependency should be switched back from the temporary DHI branch pin to `dhi` main.
