### PR TITLE
Add multicore event loop benchmark support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zig-out/
 zig-pkg/
 codedb.snapshot
+bench-results/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ zig build -Doptimize=ReleaseFast http-server -- 8080
 zig build -Doptimize=ReleaseFast http-server -- 8080 event_loop
 ```
 
+The dispatch benchmark covers root dispatch, typed path/query dispatch, exact
+static route lookup at 64 routes, direct typed path/query parsing, request
+header/cookie helpers, typed JSON body parsing, and raw turboapi-core lookup.
+
 Example local `wrk` profile:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Example local `wrk` profile:
 wrk -t4 -c64 -d10s --latency http://127.0.0.1:8080/
 wrk -t4 -c64 -d10s --latency 'http://127.0.0.1:8080/users/42?verbose=true'
 ./scripts/bench-http.sh
+./scripts/check-dispatch-bench.sh
 ```
 
 ## Feature Shape

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NanoAPI is a pure Zig HTTP API framework with FastAPI-inspired ergonomics:
 typed route parameters, response helpers, OpenAPI metadata, streaming responses,
-and a small native HTTP/1.1 server.
+and a small multi-worker native HTTP/1.1 server.
 
 The hot routing path is backed by `turboapi-core`, while validation primitives
 come from `dhi`. The current dependency pin uses the `dhi` performance branch
@@ -111,7 +111,9 @@ fn download(req: *nano.Request) !nano.Response {
 The built-in server is a compact HTTP/1.1 implementation with keep-alive. The
 default runtime is `.auto`: on macOS and BSD targets it uses the kqueue event
 loop; elsewhere it falls back to thread-per-connection until another event
-backend is added.
+backend is added. The event-loop runtime is multicore by default: worker count
+`0` means one listener/loop per logical CPU using `SO_REUSEPORT` where the OS
+supports it.
 
 The hot response path avoids unnecessary allocations and omits redundant
 `Connection: keep-alive` headers for HTTP/1.1 responses.
@@ -121,6 +123,7 @@ try app.listenAndServe(std.heap.smp_allocator, .{
     .host = .{ 127, 0, 0, 1 },
     .port = 8080,
     .runtime = .auto,
+    .worker_threads = 0,
 });
 ```
 
@@ -134,20 +137,36 @@ NanoAPI is currently optimized around a small number of hot paths:
 - typed routes skip DHI validation when no validation convention is present
 - common `200 application/json` byte responses use a compact fast write path
 - HTTP/1.1 keep-alive responses avoid redundant connection headers
+- kqueue event-loop workers can spread accepted connections across cores
 
-Recent local comparison against `karlseguin/http.zig` using equivalent handlers:
+Recent local comparison using equivalent JSON handlers:
 
-| Route | NanoAPI | http.zig |
-| --- | ---: | ---: |
-| `/` | ~168k req/s | ~166k req/s |
-| `/users/42?verbose=true` | ~167k req/s | ~166k req/s |
+Environment: macOS arm64, Zig 0.16.0, `wrk 4.2.0`, `-t4 -c64 -d3s`.
+NanoAPI used `event_loop` with `worker_threads=0` (auto). The Rust comparison
+servers used 4 workers.
+
+| Framework | `/` | `/users/42?verbose=true` | `/auth` | Average | vs NanoAPI |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| NanoAPI | 148.1k | 149.5k | 149.4k | 149.0k | 1.00x |
+| Rust Actix Web | 152.7k | 151.1k | 151.9k | 151.9k | 1.02x |
+| Rust xitca-web | 152.6k | 150.5k | 150.6k | 151.3k | 1.02x |
+| turboAPI | 146.7k | 146.0k | 127.1k | 139.9k | 0.94x |
+| http.zig | 130.8k | 129.5k | 132.7k | 131.0k | 0.88x |
+| Go Fiber | 110.9k | 110.3k | 110.9k | 110.7k | 0.74x |
+| Go net/http | 99.8k | 96.7k | 92.8k | 96.4k | 0.65x |
+| FastAPI + uvicorn | 10.1k | 8.7k | 8.7k | 9.1k | 0.06x |
+
+Higher client concurrency was not better on this localhost profile. With
+`wrk -t8 -c128 -d5s`, NanoAPI averaged 134.6k req/s, Actix averaged 130.6k
+req/s, and xitca-web averaged 134.8k req/s.
 
 Treat these numbers as directional; they vary by machine, thermal state, Zig
 build, and background load.
 
-The next likely performance wins are request/response arena reuse, vectorized or
-lower-copy writes, better request parser state reuse, specialized typed query
-parsers, and a reproducible benchmark suite with regression thresholds.
+The next likely performance wins are worker scheduling/backlog tuning,
+request/response arena reuse, lower-copy writes, better request parser state
+reuse, specialized typed query parsers, and stricter benchmark regression
+thresholds.
 
 ## Build And Bench
 
@@ -157,6 +176,7 @@ zig build -Doptimize=ReleaseFast bench -- 10000000
 zig build -Doptimize=ReleaseFast bench -- 1000000 --warmup 100000 --repeat 5 --format=json
 zig build -Doptimize=ReleaseFast http-server -- 8080
 zig build -Doptimize=ReleaseFast http-server -- 8080 event_loop
+zig build -Doptimize=ReleaseFast http-server -- 8080 event_loop 4
 ```
 
 The dispatch benchmark covers root dispatch, typed path/query dispatch, exact
@@ -169,6 +189,7 @@ Example local `wrk` profile:
 wrk -t4 -c64 -d10s --latency http://127.0.0.1:8080/
 wrk -t4 -c64 -d10s --latency 'http://127.0.0.1:8080/users/42?verbose=true'
 ./scripts/bench-http.sh
+WORKERS=4 ./scripts/bench-http.sh
 ./scripts/check-dispatch-bench.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ parsers, and a reproducible benchmark suite with regression thresholds.
 ```bash
 zig build test
 zig build -Doptimize=ReleaseFast bench -- 10000000
+zig build -Doptimize=ReleaseFast bench -- 1000000 --warmup 100000 --repeat 5 --format=json
 zig build -Doptimize=ReleaseFast http-server -- 8080
+zig build -Doptimize=ReleaseFast http-server -- 8080 event_loop
 ```
 
 Example local `wrk` profile:
@@ -162,6 +164,7 @@ Example local `wrk` profile:
 ```bash
 wrk -t4 -c64 -d10s --latency http://127.0.0.1:8080/
 wrk -t4 -c64 -d10s --latency 'http://127.0.0.1:8080/users/42?verbose=true'
+./scripts/bench-http.sh
 ```
 
 ## Feature Shape

--- a/bench/dispatch.zig
+++ b/bench/dispatch.zig
@@ -9,6 +9,42 @@ const QueryParams = struct {
     verbose: bool = false,
 };
 
+const OutputFormat = enum {
+    text,
+    json,
+};
+
+const Config = struct {
+    iterations: u64 = 1_000_000,
+    warmup: u64 = 0,
+    repeat: u32 = 1,
+    format: OutputFormat = .text,
+};
+
+const BenchResult = struct {
+    name: []const u8,
+    iterations: u64,
+    elapsed_ns: u64,
+    checksum: u64,
+};
+
+const BenchSummary = struct {
+    name: []const u8,
+    iterations: u64,
+    repeat: u32,
+    min_ns: u64 = std.math.maxInt(u64),
+    max_ns: u64 = 0,
+    total_ns: u128 = 0,
+    checksum: u64 = 0,
+
+    fn add(self: *BenchSummary, result: BenchResult) void {
+        self.min_ns = @min(self.min_ns, result.elapsed_ns);
+        self.max_ns = @max(self.max_ns, result.elapsed_ns);
+        self.total_ns += result.elapsed_ns;
+        self.checksum +%= result.checksum;
+    }
+};
+
 fn typedUser(ctx: nano.typed.Context(PathParams, QueryParams)) anyerror!nano.Response {
     const body = try std.fmt.allocPrint(
         ctx.raw.allocator,
@@ -24,7 +60,7 @@ fn staticHandler(req: *nano.Request) anyerror!nano.Response {
 
 pub fn main(init: std.process.Init) !void {
     const allocator = std.heap.smp_allocator;
-    const iterations = try iterationsFromArgs(init.minimal.args);
+    const config = try configFromArgs(init.minimal.args);
 
     var api = try nano.NanoAPI.init(allocator, .{ .title = "Bench" });
     defer api.deinit();
@@ -35,12 +71,28 @@ pub fn main(init: std.process.Init) !void {
     var static_req = nano.Request.init(allocator, "GET", "/", &.{}, "");
     var typed_req = nano.Request.init(allocator, "GET", "/users/42?verbose=true", &.{}, "");
 
-    try benchRoute(init.io, "nano dispatch static", &api, &static_req, iterations);
-    try benchRoute(init.io, "nano dispatch typed param+query", &api, &typed_req, iterations);
-    try benchCoreRouter(init.io, allocator, iterations);
+    if (config.warmup > 0) {
+        _ = try benchRoute(init.io, "nano dispatch static", &api, &static_req, config.warmup);
+        _ = try benchRoute(init.io, "nano dispatch typed param+query", &api, &typed_req, config.warmup);
+        _ = try benchCoreRouter(init.io, allocator, config.warmup);
+    }
+
+    var summaries = [_]BenchSummary{
+        .{ .name = "nano dispatch static", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano dispatch typed param+query", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "turboapi-core route lookup", .iterations = config.iterations, .repeat = config.repeat },
+    };
+
+    for (0..config.repeat) |_| {
+        summaries[0].add(try benchRoute(init.io, summaries[0].name, &api, &static_req, config.iterations));
+        summaries[1].add(try benchRoute(init.io, summaries[1].name, &api, &typed_req, config.iterations));
+        summaries[2].add(try benchCoreRouter(init.io, allocator, config.iterations));
+    }
+
+    printSummaries(&summaries, config.format);
 }
 
-fn benchRoute(io: std.Io, name: []const u8, api: *nano.NanoAPI, req: *nano.Request, iterations: u64) !void {
+fn benchRoute(io: std.Io, name: []const u8, api: *nano.NanoAPI, req: *nano.Request, iterations: u64) !BenchResult {
     var checksum: u64 = 0;
     const start = std.Io.Clock.awake.now(io);
 
@@ -52,10 +104,15 @@ fn benchRoute(io: std.Io, name: []const u8, api: *nano.NanoAPI, req: *nano.Reque
     }
 
     const elapsed_ns = elapsedNs(start, io);
-    printResult(name, iterations, elapsed_ns, checksum);
+    return .{
+        .name = name,
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
 }
 
-fn benchCoreRouter(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !void {
+fn benchCoreRouter(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
     var router = nano.core.Router.init(allocator);
     defer router.deinit();
 
@@ -73,7 +130,12 @@ fn benchCoreRouter(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !v
     }
 
     const elapsed_ns = elapsedNs(start, io);
-    printResult("turboapi-core route lookup", iterations, elapsed_ns, checksum);
+    return .{
+        .name = "turboapi-core route lookup",
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
 }
 
 fn elapsedNs(start: std.Io.Timestamp, io: std.Io) u64 {
@@ -81,24 +143,98 @@ fn elapsedNs(start: std.Io.Timestamp, io: std.Io) u64 {
     return @intCast(start.durationTo(end).toNanoseconds());
 }
 
+fn printSummaries(summaries: []const BenchSummary, format: OutputFormat) void {
+    switch (format) {
+        .text => {
+            for (summaries) |summary| {
+                if (summary.repeat == 1) {
+                    printResult(summary.name, summary.iterations, summary.min_ns, summary.checksum);
+                } else {
+                    printRepeatedResult(summary);
+                }
+            }
+        },
+        .json => printJsonSummaries(summaries),
+    }
+}
+
 fn printResult(name: []const u8, iterations: u64, elapsed_ns: u64, checksum: u64) void {
-    const seconds = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0;
+    const seconds = secondsFromNs(elapsed_ns);
     const ops = @as(f64, @floatFromInt(iterations)) / seconds;
-    const ns_per = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(iterations));
+    const ns_per = nsPerOp(elapsed_ns, iterations);
     std.debug.print("{s}: {d} ops in {d:.3}s = {d:.2} ops/s, {d:.2} ns/op (checksum={d})\n", .{
-        name,
-        iterations,
-        seconds,
-        ops,
-        ns_per,
-        checksum,
+        name, iterations, seconds, ops, ns_per, checksum,
     });
 }
 
-fn iterationsFromArgs(args_state: std.process.Args) !u64 {
+fn printRepeatedResult(summary: BenchSummary) void {
+    const avg_ns = @as(f64, @floatFromInt(summary.total_ns)) / @as(f64, @floatFromInt(summary.repeat));
+    std.debug.print(
+        "{s}: {d} ops x {d} repeats, min {d:.2} ns/op, avg {d:.2} ns/op, max {d:.2} ns/op (checksum={d})\n",
+        .{
+            summary.name,
+            summary.iterations,
+            summary.repeat,
+            nsPerOp(summary.min_ns, summary.iterations),
+            avg_ns / @as(f64, @floatFromInt(summary.iterations)),
+            nsPerOp(summary.max_ns, summary.iterations),
+            summary.checksum,
+        },
+    );
+}
+
+fn printJsonSummaries(summaries: []const BenchSummary) void {
+    std.debug.print("[\n", .{});
+    for (summaries, 0..) |summary, i| {
+        const avg_ns = @as(f64, @floatFromInt(summary.total_ns)) / @as(f64, @floatFromInt(summary.repeat));
+        std.debug.print(
+            "  {{\"name\":\"{s}\",\"iterations\":{d},\"repeat\":{d},\"min_ns_per_op\":{d:.3},\"avg_ns_per_op\":{d:.3},\"max_ns_per_op\":{d:.3},\"checksum\":{d}}}{s}\n",
+            .{
+                summary.name,
+                summary.iterations,
+                summary.repeat,
+                nsPerOp(summary.min_ns, summary.iterations),
+                avg_ns / @as(f64, @floatFromInt(summary.iterations)),
+                nsPerOp(summary.max_ns, summary.iterations),
+                summary.checksum,
+                if (i + 1 == summaries.len) "" else ",",
+            },
+        );
+    }
+    std.debug.print("]\n", .{});
+}
+
+fn secondsFromNs(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / 1_000_000_000.0;
+}
+
+fn nsPerOp(ns: u64, iterations: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / @as(f64, @floatFromInt(iterations));
+}
+
+fn configFromArgs(args_state: std.process.Args) !Config {
     var args = std.process.Args.Iterator.init(args_state);
     defer args.deinit();
     _ = args.next();
-    const raw = args.next() orelse return 1_000_000;
-    return try std.fmt.parseInt(u64, raw, 10);
+
+    var config: Config = .{};
+    var saw_iterations = false;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--format=json")) {
+            config.format = .json;
+        } else if (std.mem.eql(u8, arg, "--warmup")) {
+            const raw = args.next() orelse return error.MissingArgument;
+            config.warmup = try std.fmt.parseInt(u64, raw, 10);
+        } else if (std.mem.eql(u8, arg, "--repeat")) {
+            const raw = args.next() orelse return error.MissingArgument;
+            config.repeat = try std.fmt.parseInt(u32, raw, 10);
+            if (config.repeat == 0) return error.InvalidRepeat;
+        } else if (!saw_iterations) {
+            config.iterations = try std.fmt.parseInt(u64, arg, 10);
+            saw_iterations = true;
+        } else {
+            return error.UnknownArgument;
+        }
+    }
+    return config;
 }

--- a/bench/dispatch.zig
+++ b/bench/dispatch.zig
@@ -9,6 +9,25 @@ const QueryParams = struct {
     verbose: bool = false,
 };
 
+const ManyPathParams = struct {
+    org_id: u8,
+    user_id: i64,
+    slug: []const u8,
+};
+
+const ManyQueryParams = struct {
+    verbose: bool = false,
+    limit: u16,
+    offset: u16 = 0,
+    term: []const u8,
+};
+
+const BodyModel = struct {
+    user_id: i64,
+    active: bool,
+    name: []const u8,
+};
+
 const OutputFormat = enum {
     text,
     json,
@@ -58,6 +77,10 @@ fn staticHandler(req: *nano.Request) anyerror!nano.Response {
     return nano.JSONResponse.init(req.allocator, "{\"ok\":true}", .{});
 }
 
+fn staticNoAllocHandler(req: *nano.Request) anyerror!nano.Response {
+    return nano.JSONResponse.static(req.allocator, "{\"ok\":true}", .{});
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = std.heap.smp_allocator;
     const config = try configFromArgs(init.minimal.args);
@@ -74,19 +97,34 @@ pub fn main(init: std.process.Init) !void {
     if (config.warmup > 0) {
         _ = try benchRoute(init.io, "nano dispatch static", &api, &static_req, config.warmup);
         _ = try benchRoute(init.io, "nano dispatch typed param+query", &api, &typed_req, config.warmup);
+        _ = try benchExactStaticRoutes(init.io, allocator, config.warmup);
+        _ = try benchTypedPathParser(init.io, allocator, config.warmup);
+        _ = try benchTypedQueryParser(init.io, allocator, config.warmup);
+        _ = try benchRequestHelpers(init.io, allocator, config.warmup);
+        _ = try benchTypedBodyParser(init.io, allocator, config.warmup);
         _ = try benchCoreRouter(init.io, allocator, config.warmup);
     }
 
     var summaries = [_]BenchSummary{
         .{ .name = "nano dispatch static", .iterations = config.iterations, .repeat = config.repeat },
         .{ .name = "nano dispatch typed param+query", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano dispatch exact static x64", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano typed parse path multi", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano typed parse query multi", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano request headers/cookies", .iterations = config.iterations, .repeat = config.repeat },
+        .{ .name = "nano typed parse JSON body", .iterations = config.iterations, .repeat = config.repeat },
         .{ .name = "turboapi-core route lookup", .iterations = config.iterations, .repeat = config.repeat },
     };
 
     for (0..config.repeat) |_| {
         summaries[0].add(try benchRoute(init.io, summaries[0].name, &api, &static_req, config.iterations));
         summaries[1].add(try benchRoute(init.io, summaries[1].name, &api, &typed_req, config.iterations));
-        summaries[2].add(try benchCoreRouter(init.io, allocator, config.iterations));
+        summaries[2].add(try benchExactStaticRoutes(init.io, allocator, config.iterations));
+        summaries[3].add(try benchTypedPathParser(init.io, allocator, config.iterations));
+        summaries[4].add(try benchTypedQueryParser(init.io, allocator, config.iterations));
+        summaries[5].add(try benchRequestHelpers(init.io, allocator, config.iterations));
+        summaries[6].add(try benchTypedBodyParser(init.io, allocator, config.iterations));
+        summaries[7].add(try benchCoreRouter(init.io, allocator, config.iterations));
     }
 
     printSummaries(&summaries, config.format);
@@ -106,6 +144,172 @@ fn benchRoute(io: std.Io, name: []const u8, api: *nano.NanoAPI, req: *nano.Reque
     const elapsed_ns = elapsedNs(start, io);
     return .{
         .name = name,
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
+}
+
+fn benchExactStaticRoutes(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
+    var api = try nano.NanoAPI.init(allocator, .{ .title = "Exact route bench" });
+    defer api.deinit();
+
+    var route_buf: [64]u8 = undefined;
+    var route_idx: usize = 0;
+    while (route_idx < 64) : (route_idx += 1) {
+        const path = try std.fmt.bufPrint(&route_buf, "/static-{d}", .{route_idx});
+        try api.get(path, staticNoAllocHandler, .{});
+    }
+
+    var req = nano.Request.init(allocator, "GET", "/static-63", &.{}, "");
+    return benchRoute(io, "nano dispatch exact static x64", &api, &req, iterations);
+}
+
+fn benchTypedPathParser(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
+    var params = [_]nano.core.RouteParams{ .{}, .{}, .{}, .{} };
+    params[0].put("org_id", "7");
+    params[0].put("user_id", "42");
+    params[0].put("slug", "rach");
+    params[1].put("org_id", "8");
+    params[1].put("user_id", "43");
+    params[1].put("slug", "zig");
+    params[2].put("org_id", "9");
+    params[2].put("user_id", "44");
+    params[2].put("slug", "nano");
+    params[3].put("org_id", "10");
+    params[3].put("user_id", "45");
+    params[3].put("slug", "api");
+
+    var reqs = [_]nano.Request{
+        nano.Request.init(allocator, "GET", "/orgs/7/users/42/rach", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/orgs/8/users/43/zig", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/orgs/9/users/44/nano", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/orgs/10/users/45/api", &.{}, ""),
+    };
+    for (&reqs, 0..) |*req, idx| req.setPathParams(&params[idx]);
+
+    std.mem.doNotOptimizeAway(&params);
+    std.mem.doNotOptimizeAway(&reqs);
+
+    var checksum: u64 = 0;
+    const start = std.Io.Clock.awake.now(io);
+
+    var i: u64 = 0;
+    while (i < iterations) : (i += 1) {
+        const idx: usize = @intCast(i & 3);
+        const parsed = try nano.typed.parsePath(ManyPathParams, &reqs[idx]);
+        checksum +%= @as(u64, parsed.org_id);
+        checksum +%= @intCast(parsed.user_id);
+        checksum +%= parsed.slug.len;
+    }
+
+    const elapsed_ns = elapsedNs(start, io);
+    return .{
+        .name = "nano typed parse path multi",
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
+}
+
+fn benchTypedQueryParser(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
+    var reqs = [_]nano.Request{
+        nano.Request.init(allocator, "GET", "/search?verbose=true&limit=10&offset=25&term=zig", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/search?verbose=false&limit=11&offset=26&term=nano", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/search?limit=12&term=api&offset=27&verbose=1", &.{}, ""),
+        nano.Request.init(allocator, "GET", "/search?offset=28&term=bench&limit=13&verbose=0", &.{}, ""),
+    };
+
+    std.mem.doNotOptimizeAway(&reqs);
+
+    var checksum: u64 = 0;
+    const start = std.Io.Clock.awake.now(io);
+
+    var i: u64 = 0;
+    while (i < iterations) : (i += 1) {
+        const idx: usize = @intCast(i & 3);
+        const parsed = try nano.typed.parseQuery(ManyQueryParams, &reqs[idx]);
+        checksum +%= @as(u64, parsed.limit) + parsed.offset + parsed.term.len + @intFromBool(parsed.verbose);
+    }
+
+    const elapsed_ns = elapsedNs(start, io);
+    return .{
+        .name = "nano typed parse query multi",
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
+}
+
+fn benchRequestHelpers(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
+    const headers_a = [_]nano.HeaderPair{
+        .{ .name = "Host", .value = "127.0.0.1" },
+        .{ .name = "Authorization", .value = "Bearer bench-token" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Cookie", .value = "session=bench; theme=dark; flags=fast" },
+        .{ .name = "User-Agent", .value = "wrk" },
+    };
+    const headers_b = [_]nano.HeaderPair{
+        .{ .name = "Host", .value = "127.0.0.1" },
+        .{ .name = "Authorization", .value = "Bearer second-token" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Cookie", .value = "session=other; theme=light; flags=typed" },
+        .{ .name = "User-Agent", .value = "wrk" },
+    };
+    var reqs = [_]nano.Request{
+        nano.Request.init(allocator, "GET", "/auth", &headers_a, ""),
+        nano.Request.init(allocator, "GET", "/auth", &headers_b, ""),
+    };
+
+    std.mem.doNotOptimizeAway(&reqs);
+
+    var checksum: u64 = 0;
+    const start = std.Io.Clock.awake.now(io);
+
+    var i: u64 = 0;
+    while (i < iterations) : (i += 1) {
+        const req = &reqs[@intCast(i & 1)];
+        checksum +%= (req.header("authorization") orelse @as([]const u8, "")).len;
+        checksum +%= (req.header("content-type") orelse @as([]const u8, "")).len;
+        checksum +%= (req.header("user-agent") orelse @as([]const u8, "")).len;
+        checksum +%= (req.cookie("session") orelse @as([]const u8, "")).len;
+        checksum +%= (req.cookie("theme") orelse @as([]const u8, "")).len;
+    }
+
+    const elapsed_ns = elapsedNs(start, io);
+    return .{
+        .name = "nano request headers/cookies",
+        .iterations = iterations,
+        .elapsed_ns = elapsed_ns,
+        .checksum = checksum,
+    };
+}
+
+fn benchTypedBodyParser(io: std.Io, allocator: std.mem.Allocator, iterations: u64) !BenchResult {
+    var reqs = [_]nano.Request{
+        nano.Request.init(allocator, "POST", "/users", &.{}, "{\"user_id\":42,\"active\":true,\"name\":\"rach\"}"),
+        nano.Request.init(allocator, "POST", "/users", &.{}, "{\"user_id\":43,\"active\":false,\"name\":\"zig\"}"),
+        nano.Request.init(allocator, "POST", "/users", &.{}, "{\"user_id\":44,\"active\":true,\"name\":\"nano\"}"),
+        nano.Request.init(allocator, "POST", "/users", &.{}, "{\"user_id\":45,\"active\":false,\"name\":\"api\"}"),
+    };
+
+    std.mem.doNotOptimizeAway(&reqs);
+
+    var checksum: u64 = 0;
+    const start = std.Io.Clock.awake.now(io);
+
+    var i: u64 = 0;
+    while (i < iterations) : (i += 1) {
+        const idx: usize = @intCast(i & 3);
+        const parsed = try nano.typed.parseBody(BodyModel, &reqs[idx]);
+        checksum +%= @intCast(parsed.user_id);
+        checksum +%= @intFromBool(parsed.active);
+        checksum +%= parsed.name.len;
+    }
+
+    const elapsed_ns = elapsedNs(start, io);
+    return .{
+        .name = "nano typed parse JSON body",
         .iterations = iterations,
         .elapsed_ns = elapsed_ns,
         .checksum = checksum,

--- a/bench/http_server.zig
+++ b/bench/http_server.zig
@@ -18,6 +18,7 @@ const BodyModel = struct {
 const Config = struct {
     port: u16 = 8080,
     runtime: nano.server.Runtime = .auto,
+    worker_threads: usize = 0,
     check_only: bool = false,
 };
 
@@ -45,8 +46,8 @@ fn createUser(ctx: nano.typed.ContextWithBody(nano.typed.Empty, nano.typed.Empty
 
 fn auth(req: *nano.Request) anyerror!nano.Response {
     const bearer = req.header("authorization") orelse "";
-    const session = req.cookie("session") orelse "";
-    if (bearer.len == 0 or session.len == 0) {
+    const cookie = req.header("cookie") orelse "";
+    if (bearer.len == 0 or std.mem.indexOf(u8, cookie, "session=") == null) {
         return nano.JSONResponse.static(req.allocator, "{\"authorized\":false}", .{});
     }
     return nano.JSONResponse.static(req.allocator, "{\"authorized\":true}", .{});
@@ -82,10 +83,14 @@ pub fn main(init: std.process.Init) !void {
     if (config.check_only) return;
 
     std.debug.print(
-        "nanoapi HTTP benchmark server listening on http://127.0.0.1:{d} runtime={t}\n",
-        .{ config.port, config.runtime },
+        "nanoapi HTTP benchmark server listening on http://127.0.0.1:{d} runtime={t} workers={d}\n",
+        .{ config.port, config.runtime, config.worker_threads },
     );
-    try nano.server.serve(&app, allocator, .{ .port = config.port, .runtime = config.runtime });
+    try nano.server.serve(&app, allocator, .{
+        .port = config.port,
+        .runtime = config.runtime,
+        .worker_threads = config.worker_threads,
+    });
 }
 
 fn configFromArgs(args_state: std.process.Args) !Config {
@@ -95,14 +100,18 @@ fn configFromArgs(args_state: std.process.Args) !Config {
 
     var config: Config = .{};
     var saw_port = false;
+    var saw_runtime = false;
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--check")) {
             config.check_only = true;
         } else if (!saw_port) {
             config.port = try std.fmt.parseInt(u16, arg, 10);
             saw_port = true;
-        } else {
+        } else if (!saw_runtime) {
             config.runtime = try parseRuntime(arg);
+            saw_runtime = true;
+        } else {
+            config.worker_threads = try std.fmt.parseInt(usize, arg, 10);
         }
     }
     return config;

--- a/bench/http_server.zig
+++ b/bench/http_server.zig
@@ -46,6 +46,10 @@ fn eventStream(req: *nano.Request) anyerror!nano.Response {
     return nano.EventSourceResponse.init(req.allocator, events, .{});
 }
 
+fn file(req: *nano.Request) anyerror!nano.Response {
+    return nano.FileResponse.init(req.allocator, "README.md", null, .{});
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = std.heap.smp_allocator;
     const config = try configFromArgs(init.minimal.args);
@@ -57,6 +61,7 @@ pub fn main(init: std.process.Init) !void {
     try app.getTyped(PathParams, QueryParams, "/users/{user_id}", user, .{});
     try app.get("/auth", auth, .{});
     try app.get("/events", eventStream, .{});
+    try app.get("/file", file, .{});
 
     if (config.check_only) return;
 

--- a/bench/http_server.zig
+++ b/bench/http_server.zig
@@ -9,6 +9,12 @@ const QueryParams = struct {
     verbose: bool = false,
 };
 
+const Config = struct {
+    port: u16 = 8080,
+    runtime: nano.server.Runtime = .auto,
+    check_only: bool = false,
+};
+
 fn root(req: *nano.Request) anyerror!nano.Response {
     return nano.JSONResponse.static(req.allocator, "{\"ok\":true}", .{});
 }
@@ -22,24 +28,68 @@ fn user(ctx: nano.typed.Context(PathParams, QueryParams)) anyerror!nano.Response
     return nano.Response.fromOwnedBody(ctx.raw.allocator, body, .{ .media_type = "application/json" });
 }
 
+fn auth(req: *nano.Request) anyerror!nano.Response {
+    const bearer = req.header("authorization") orelse "";
+    const session = req.cookie("session") orelse "";
+    if (bearer.len == 0 or session.len == 0) {
+        return nano.JSONResponse.static(req.allocator, "{\"authorized\":false}", .{});
+    }
+    return nano.JSONResponse.static(req.allocator, "{\"authorized\":true}", .{});
+}
+
+fn events(ctx: *nano.StreamContext) anyerror!void {
+    var writer = nano.SseWriter.init(ctx);
+    try writer.event("ready", "1", "1");
+}
+
+fn eventStream(req: *nano.Request) anyerror!nano.Response {
+    return nano.EventSourceResponse.init(req.allocator, events, .{});
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = std.heap.smp_allocator;
-    const port = try portFromArgs(init.minimal.args);
+    const config = try configFromArgs(init.minimal.args);
 
     var app = try nano.NanoAPI.init(allocator, .{ .title = "NanoAPI wrk bench" });
     defer app.deinit();
 
     try app.get("/", root, .{});
     try app.getTyped(PathParams, QueryParams, "/users/{user_id}", user, .{});
+    try app.get("/auth", auth, .{});
+    try app.get("/events", eventStream, .{});
 
-    std.debug.print("nanoapi HTTP benchmark server listening on http://127.0.0.1:{d}\n", .{port});
-    try nano.server.serve(&app, allocator, .{ .port = port });
+    if (config.check_only) return;
+
+    std.debug.print(
+        "nanoapi HTTP benchmark server listening on http://127.0.0.1:{d} runtime={t}\n",
+        .{ config.port, config.runtime },
+    );
+    try nano.server.serve(&app, allocator, .{ .port = config.port, .runtime = config.runtime });
 }
 
-fn portFromArgs(args_state: std.process.Args) !u16 {
+fn configFromArgs(args_state: std.process.Args) !Config {
     var args = std.process.Args.Iterator.init(args_state);
     defer args.deinit();
     _ = args.next();
-    const raw = args.next() orelse return 8080;
-    return try std.fmt.parseInt(u16, raw, 10);
+
+    var config: Config = .{};
+    var saw_port = false;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--check")) {
+            config.check_only = true;
+        } else if (!saw_port) {
+            config.port = try std.fmt.parseInt(u16, arg, 10);
+            saw_port = true;
+        } else {
+            config.runtime = try parseRuntime(arg);
+        }
+    }
+    return config;
+}
+
+fn parseRuntime(raw: []const u8) !nano.server.Runtime {
+    if (std.mem.eql(u8, raw, "auto")) return .auto;
+    if (std.mem.eql(u8, raw, "event_loop")) return .event_loop;
+    if (std.mem.eql(u8, raw, "thread_per_connection")) return .thread_per_connection;
+    return error.InvalidRuntime;
 }

--- a/bench/http_server.zig
+++ b/bench/http_server.zig
@@ -9,6 +9,12 @@ const QueryParams = struct {
     verbose: bool = false,
 };
 
+const BodyModel = struct {
+    user_id: i64,
+    active: bool,
+    name: []const u8,
+};
+
 const Config = struct {
     port: u16 = 8080,
     runtime: nano.server.Runtime = .auto,
@@ -24,6 +30,15 @@ fn user(ctx: nano.typed.Context(PathParams, QueryParams)) anyerror!nano.Response
         ctx.raw.allocator,
         "{{\"user_id\":{d},\"verbose\":{s}}}",
         .{ ctx.path.user_id, if (ctx.query.verbose) "true" else "false" },
+    );
+    return nano.Response.fromOwnedBody(ctx.raw.allocator, body, .{ .media_type = "application/json" });
+}
+
+fn createUser(ctx: nano.typed.ContextWithBody(nano.typed.Empty, nano.typed.Empty, BodyModel)) anyerror!nano.Response {
+    const body = try std.fmt.allocPrint(
+        ctx.raw.allocator,
+        "{{\"user_id\":{d},\"active\":{s},\"name\":\"{s}\"}}",
+        .{ ctx.body.user_id, if (ctx.body.active) "true" else "false", ctx.body.name },
     );
     return nano.Response.fromOwnedBody(ctx.raw.allocator, body, .{ .media_type = "application/json" });
 }
@@ -59,6 +74,7 @@ pub fn main(init: std.process.Init) !void {
 
     try app.get("/", root, .{});
     try app.getTyped(PathParams, QueryParams, "/users/{user_id}", user, .{});
+    try app.postTypedBody(nano.typed.Empty, nano.typed.Empty, BodyModel, "/users", createUser, .{});
     try app.get("/auth", auth, .{});
     try app.get("/events", eventStream, .{});
     try app.get("/file", file, .{});

--- a/scripts/bench-http.sh
+++ b/scripts/bench-http.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8080}"
+DURATION="${DURATION:-10s}"
+THREADS="${THREADS:-4}"
+CONNECTIONS="${CONNECTIONS:-64}"
+RUNTIME="${RUNTIME:-auto}"
+OUT_DIR="${OUT_DIR:-bench-results}"
+
+if ! command -v wrk >/dev/null 2>&1; then
+  echo "error: wrk is required for HTTP benchmarks" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+server_args=("$PORT")
+if [[ "$RUNTIME" != "auto" ]]; then
+  server_args+=("$RUNTIME")
+fi
+
+zig build -Doptimize=ReleaseFast http-server -- "${server_args[@]}" &
+server_pid=$!
+
+cleanup() {
+  kill "$server_pid" >/dev/null 2>&1 || true
+  wait "$server_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 100); do
+  if curl -fsS "http://127.0.0.1:${PORT}/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.05
+done
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+result="${OUT_DIR}/http-${stamp}.txt"
+
+{
+  echo "nanoapi HTTP benchmark"
+  echo "timestamp_utc=${stamp}"
+  echo "git_sha=$(git rev-parse --short HEAD)"
+  echo "zig_version=$(zig version)"
+  echo "runtime=${RUNTIME}"
+  echo "threads=${THREADS}"
+  echo "connections=${CONNECTIONS}"
+  echo "duration=${DURATION}"
+  echo
+
+  echo "## GET /"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/"
+  echo
+
+  echo "## GET /users/42?verbose=true"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/users/42?verbose=true"
+  echo
+
+  echo "## GET /auth"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency \
+    -H "Authorization: Bearer bench-token" \
+    -H "Cookie: session=bench; theme=dark" \
+    "http://127.0.0.1:${PORT}/auth"
+  echo
+
+  echo "## GET /events"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/events"
+} | tee "$result"
+
+echo "wrote ${result}"

--- a/scripts/bench-http.sh
+++ b/scripts/bench-http.sh
@@ -14,6 +14,7 @@ if ! command -v wrk >/dev/null 2>&1; then
 fi
 
 mkdir -p "$OUT_DIR"
+post_lua=""
 
 server_args=("$PORT")
 if [[ "$RUNTIME" != "auto" ]]; then
@@ -26,6 +27,7 @@ server_pid=$!
 cleanup() {
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
+  [[ -z "$post_lua" ]] || rm -f "$post_lua"
 }
 trap cleanup EXIT
 
@@ -38,6 +40,12 @@ done
 
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 result="${OUT_DIR}/http-${stamp}.txt"
+post_lua="$(mktemp "${OUT_DIR}/wrk-post-json.XXXXXX.lua")"
+cat >"$post_lua" <<'LUA'
+wrk.method = "POST"
+wrk.body = '{"user_id":42,"active":true,"name":"rach"}'
+wrk.headers["Content-Type"] = "application/json"
+LUA
 
 {
   echo "nanoapi HTTP benchmark"
@@ -56,6 +64,10 @@ result="${OUT_DIR}/http-${stamp}.txt"
 
   echo "## GET /users/42?verbose=true"
   wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/users/42?verbose=true"
+  echo
+
+  echo "## POST /users"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency -s "$post_lua" "http://127.0.0.1:${PORT}/users"
   echo
 
   echo "## GET /auth"

--- a/scripts/bench-http.sh
+++ b/scripts/bench-http.sh
@@ -6,6 +6,7 @@ DURATION="${DURATION:-10s}"
 THREADS="${THREADS:-4}"
 CONNECTIONS="${CONNECTIONS:-64}"
 RUNTIME="${RUNTIME:-auto}"
+WORKERS="${WORKERS:-0}"
 OUT_DIR="${OUT_DIR:-bench-results}"
 
 if ! command -v wrk >/dev/null 2>&1; then
@@ -17,8 +18,11 @@ mkdir -p "$OUT_DIR"
 post_lua=""
 
 server_args=("$PORT")
-if [[ "$RUNTIME" != "auto" ]]; then
+if [[ "$RUNTIME" != "auto" || "$WORKERS" != "0" ]]; then
   server_args+=("$RUNTIME")
+fi
+if [[ "$WORKERS" != "0" ]]; then
+  server_args+=("$WORKERS")
 fi
 
 zig build -Doptimize=ReleaseFast http-server -- "${server_args[@]}" &
@@ -53,6 +57,7 @@ LUA
   echo "git_sha=$(git rev-parse --short HEAD)"
   echo "zig_version=$(zig version)"
   echo "runtime=${RUNTIME}"
+  echo "worker_threads=${WORKERS}"
   echo "threads=${THREADS}"
   echo "connections=${CONNECTIONS}"
   echo "duration=${DURATION}"

--- a/scripts/bench-http.sh
+++ b/scripts/bench-http.sh
@@ -67,6 +67,10 @@ result="${OUT_DIR}/http-${stamp}.txt"
 
   echo "## GET /events"
   wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/events"
+  echo
+
+  echo "## GET /file"
+  wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" --latency "http://127.0.0.1:${PORT}/file"
 } | tee "$result"
 
 echo "wrote ${result}"

--- a/scripts/check-dispatch-bench.sh
+++ b/scripts/check-dispatch-bench.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ITERATIONS="${ITERATIONS:-1000000}"
+WARMUP="${WARMUP:-100000}"
+REPEAT="${REPEAT:-5}"
+STATIC_MAX_NS="${STATIC_MAX_NS:-40}"
+TYPED_MAX_NS="${TYPED_MAX_NS:-140}"
+CORE_MAX_NS="${CORE_MAX_NS:-80}"
+
+output="$(
+  zig build -Doptimize=ReleaseFast bench -- "$ITERATIONS" \
+    --warmup "$WARMUP" \
+    --repeat "$REPEAT" \
+    --format=json 2>&1
+)"
+
+printf '%s\n' "$output"
+
+extract_avg() {
+  local name="$1"
+  printf '%s\n' "$output" | awk -v name="$name" '
+    index($0, "\"name\":\"" name "\"") > 0 {
+      if (match($0, /"avg_ns_per_op":[0-9.]+/)) {
+        value = substr($0, RSTART, RLENGTH)
+        sub(/"avg_ns_per_op":/, "", value)
+        print value
+        exit
+      }
+    }
+  '
+}
+
+check_max() {
+  local label="$1"
+  local value="$2"
+  local max="$3"
+  awk -v label="$label" -v value="$value" -v max="$max" '
+    BEGIN {
+      if (value == "") {
+        printf("missing benchmark result for %s\n", label) > "/dev/stderr"
+        exit 2
+      }
+      if (value + 0 > max + 0) {
+        printf("%s regression: %.3f ns/op > %.3f ns/op\n", label, value, max) > "/dev/stderr"
+        exit 1
+      }
+      printf("%s ok: %.3f ns/op <= %.3f ns/op\n", label, value, max)
+    }
+  '
+}
+
+check_max "nano dispatch static" "$(extract_avg "nano dispatch static")" "$STATIC_MAX_NS"
+check_max "nano dispatch typed param+query" "$(extract_avg "nano dispatch typed param+query")" "$TYPED_MAX_NS"
+check_max "turboapi-core route lookup" "$(extract_avg "turboapi-core route lookup")" "$CORE_MAX_NS"

--- a/src/app.zig
+++ b/src/app.zig
@@ -102,6 +102,18 @@ pub const App = struct {
         try typed.get(self, PathParams, QueryParams, path, handler, route_options);
     }
 
+    pub fn postTypedBody(
+        self: *App,
+        comptime PathParams: type,
+        comptime QueryParams: type,
+        comptime BodyModel: type,
+        path: []const u8,
+        comptime handler: typed.HandlerWithBody(PathParams, QueryParams, BodyModel),
+        route_options: meta.RouteOptions,
+    ) !void {
+        try typed.postWithBody(self, PathParams, QueryParams, BodyModel, path, handler, route_options);
+    }
+
     pub fn post(self: *App, path: []const u8, handler: routing.Handler, route_options: meta.RouteOptions) !void {
         try self.router.post(path, handler, route_options);
     }

--- a/src/request.zig
+++ b/src/request.zig
@@ -14,7 +14,7 @@ pub const Request = struct {
     path_params: ?*const core.RouteParams = null,
     header_cache: HeaderCache = .{},
 
-    const CommonHeader = enum {
+    pub const CommonHeader = enum {
         accept,
         authorization,
         content_type,
@@ -23,13 +23,13 @@ pub const Request = struct {
         user_agent,
     };
 
-    const CachedHeader = union(enum) {
+    pub const CachedHeader = union(enum) {
         hit: []const u8,
         miss,
         invalid,
     };
 
-    const HeaderCache = struct {
+    pub const HeaderCache = struct {
         source_ptr: ?[*]const HeaderPair = null,
         source_len: usize = 0,
         accept: ?usize = null,
@@ -39,25 +39,35 @@ pub const Request = struct {
         host: ?usize = null,
         user_agent: ?usize = null,
 
-        fn init(headers: []const HeaderPair) HeaderCache {
-            var cache: HeaderCache = .{
-                .source_ptr = if (headers.len == 0) null else headers.ptr,
-                .source_len = headers.len,
-            };
+        pub fn init(headers: []const HeaderPair) HeaderCache {
+            var cache = initForBuffer(headers);
             for (headers, 0..) |h, idx| {
-                if (commonHeaderId(h.name)) |id| cache.setFirst(id, idx);
+                cache.observe(h.name, idx);
             }
+            cache.finish(headers);
             return cache;
         }
 
-        fn lookup(self: *const HeaderCache, headers: []const HeaderPair, id: CommonHeader) CachedHeader {
+        pub fn initForBuffer(headers: []const HeaderPair) HeaderCache {
+            return .{
+                .source_ptr = if (headers.len == 0) null else headers.ptr,
+            };
+        }
+
+        pub fn finish(self: *HeaderCache, headers: []const HeaderPair) void {
+            self.source_ptr = if (headers.len == 0) null else headers.ptr;
+            self.source_len = headers.len;
+        }
+
+        pub fn observe(self: *HeaderCache, name: []const u8, idx: usize) void {
+            if (commonHeaderId(name)) |id| self.setFirst(id, idx);
+        }
+
+        pub fn lookup(self: *const HeaderCache, headers: []const HeaderPair, id: CommonHeader) CachedHeader {
             if (!self.matches(headers)) return .invalid;
             const idx = self.index(id) orelse return .miss;
             if (idx >= headers.len) return .invalid;
-
-            const h = headers[idx];
-            if (!commonHeaderMatches(h.name, id)) return .invalid;
-            return .{ .hit = h.value };
+            return .{ .hit = headers[idx].value };
         }
 
         fn matches(self: *const HeaderCache, headers: []const HeaderPair) bool {
@@ -133,6 +143,19 @@ pub const Request = struct {
         headers: []const HeaderPair,
         body: []const u8,
     ) Request {
+        return initPartsCached(allocator, method, target, path, query_string, headers, body, HeaderCache.init(headers));
+    }
+
+    pub fn initPartsCached(
+        allocator: std.mem.Allocator,
+        method: []const u8,
+        target: []const u8,
+        path: []const u8,
+        query_string: []const u8,
+        headers: []const HeaderPair,
+        body: []const u8,
+        header_cache: HeaderCache,
+    ) Request {
         return .{
             .allocator = allocator,
             .method = method,
@@ -141,7 +164,7 @@ pub const Request = struct {
             .query_string = query_string,
             .headers = headers,
             .body = body,
-            .header_cache = HeaderCache.init(headers),
+            .header_cache = header_cache,
         };
     }
 
@@ -245,10 +268,6 @@ fn commonHeaderName(id: Request.CommonHeader) []const u8 {
         .host => "host",
         .user_agent => "user-agent",
     };
-}
-
-fn commonHeaderMatches(name: []const u8, id: Request.CommonHeader) bool {
-    return std.ascii.eqlIgnoreCase(name, commonHeaderName(id));
 }
 
 test "Request caches common headers from initParts" {

--- a/src/request.zig
+++ b/src/request.zig
@@ -12,6 +12,95 @@ pub const Request = struct {
     headers: []const HeaderPair = &.{},
     body: []const u8 = "",
     path_params: ?*const core.RouteParams = null,
+    header_cache: HeaderCache = .{},
+
+    const CommonHeader = enum {
+        accept,
+        authorization,
+        content_type,
+        cookie,
+        host,
+        user_agent,
+    };
+
+    const CachedHeader = union(enum) {
+        hit: []const u8,
+        miss,
+        invalid,
+    };
+
+    const HeaderCache = struct {
+        source_ptr: ?[*]const HeaderPair = null,
+        source_len: usize = 0,
+        accept: ?usize = null,
+        authorization: ?usize = null,
+        content_type: ?usize = null,
+        cookie: ?usize = null,
+        host: ?usize = null,
+        user_agent: ?usize = null,
+
+        fn init(headers: []const HeaderPair) HeaderCache {
+            var cache: HeaderCache = .{
+                .source_ptr = if (headers.len == 0) null else headers.ptr,
+                .source_len = headers.len,
+            };
+            for (headers, 0..) |h, idx| {
+                if (commonHeaderId(h.name)) |id| cache.setFirst(id, idx);
+            }
+            return cache;
+        }
+
+        fn lookup(self: *const HeaderCache, headers: []const HeaderPair, id: CommonHeader) CachedHeader {
+            if (!self.matches(headers)) return .invalid;
+            const idx = self.index(id) orelse return .miss;
+            if (idx >= headers.len) return .invalid;
+
+            const h = headers[idx];
+            if (!commonHeaderMatches(h.name, id)) return .invalid;
+            return .{ .hit = h.value };
+        }
+
+        fn matches(self: *const HeaderCache, headers: []const HeaderPair) bool {
+            if (headers.len != self.source_len) return false;
+            if (headers.len == 0) return true;
+            const source_ptr = self.source_ptr orelse return false;
+            return source_ptr == headers.ptr;
+        }
+
+        fn index(self: *const HeaderCache, id: CommonHeader) ?usize {
+            return switch (id) {
+                .accept => self.accept,
+                .authorization => self.authorization,
+                .content_type => self.content_type,
+                .cookie => self.cookie,
+                .host => self.host,
+                .user_agent => self.user_agent,
+            };
+        }
+
+        fn setFirst(self: *HeaderCache, id: CommonHeader, idx: usize) void {
+            switch (id) {
+                .accept => {
+                    if (self.accept == null) self.accept = idx;
+                },
+                .authorization => {
+                    if (self.authorization == null) self.authorization = idx;
+                },
+                .content_type => {
+                    if (self.content_type == null) self.content_type = idx;
+                },
+                .cookie => {
+                    if (self.cookie == null) self.cookie = idx;
+                },
+                .host => {
+                    if (self.host == null) self.host = idx;
+                },
+                .user_agent => {
+                    if (self.user_agent == null) self.user_agent = idx;
+                },
+            }
+        }
+    };
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -31,6 +120,7 @@ pub const Request = struct {
             .query_string = query,
             .headers = headers,
             .body = body,
+            .header_cache = HeaderCache.init(headers),
         };
     }
 
@@ -51,6 +141,7 @@ pub const Request = struct {
             .query_string = query_string,
             .headers = headers,
             .body = body,
+            .header_cache = HeaderCache.init(headers),
         };
     }
 
@@ -90,14 +181,12 @@ pub const Request = struct {
     }
 
     pub fn header(self: *const Request, name: []const u8) ?[]const u8 {
-        for (self.headers) |h| {
-            if (std.ascii.eqlIgnoreCase(h.name, name)) return h.value;
-        }
-        return null;
+        if (commonHeaderId(name)) |id| return self.commonHeader(id);
+        return self.findHeader(name);
     }
 
     pub fn cookie(self: *const Request, name: []const u8) ?[]const u8 {
-        const cookie_header = self.header("cookie") orelse return null;
+        const cookie_header = self.commonHeader(.cookie) orelse return null;
         var it = std.mem.splitScalar(u8, cookie_header, ';');
         while (it.next()) |part| {
             const trimmed = std.mem.trim(u8, part, " \t");
@@ -114,4 +203,109 @@ pub const Request = struct {
         _ = self;
         return core.http.percentDecode(value, buffer);
     }
+
+    fn commonHeader(self: *const Request, id: CommonHeader) ?[]const u8 {
+        switch (self.header_cache.lookup(self.headers, id)) {
+            .hit => |value| return value,
+            .miss => return null,
+            .invalid => return self.findHeader(commonHeaderName(id)),
+        }
+    }
+
+    fn findHeader(self: *const Request, name: []const u8) ?[]const u8 {
+        for (self.headers) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, name)) return h.value;
+        }
+        return null;
+    }
 };
+
+fn commonHeaderId(name: []const u8) ?Request.CommonHeader {
+    return switch (name.len) {
+        4 => if (std.ascii.eqlIgnoreCase(name, "host")) .host else null,
+        6 => if (std.ascii.eqlIgnoreCase(name, "accept"))
+            .accept
+        else if (std.ascii.eqlIgnoreCase(name, "cookie"))
+            .cookie
+        else
+            null,
+        10 => if (std.ascii.eqlIgnoreCase(name, "user-agent")) .user_agent else null,
+        12 => if (std.ascii.eqlIgnoreCase(name, "content-type")) .content_type else null,
+        13 => if (std.ascii.eqlIgnoreCase(name, "authorization")) .authorization else null,
+        else => null,
+    };
+}
+
+fn commonHeaderName(id: Request.CommonHeader) []const u8 {
+    return switch (id) {
+        .accept => "accept",
+        .authorization => "authorization",
+        .content_type => "content-type",
+        .cookie => "cookie",
+        .host => "host",
+        .user_agent => "user-agent",
+    };
+}
+
+fn commonHeaderMatches(name: []const u8, id: Request.CommonHeader) bool {
+    return std.ascii.eqlIgnoreCase(name, commonHeaderName(id));
+}
+
+test "Request caches common headers from initParts" {
+    const headers = [_]HeaderPair{
+        .{ .name = "X-Trace-Id", .value = "trace-1" },
+        .{ .name = "Authorization", .value = "Bearer token-123" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Cookie", .value = "session=abc123; theme = dark" },
+    };
+    const req = Request.initParts(
+        std.testing.allocator,
+        "POST",
+        "/submit",
+        "/submit",
+        "",
+        &headers,
+        "{}",
+    );
+
+    try std.testing.expect(req.header_cache.authorization != null);
+    try std.testing.expect(req.header_cache.content_type != null);
+    try std.testing.expect(req.header_cache.cookie != null);
+    try std.testing.expectEqualStrings("Bearer token-123", req.header("authorization").?);
+    try std.testing.expectEqualStrings("application/json", req.header("CONTENT-TYPE").?);
+    try std.testing.expectEqualStrings("trace-1", req.header("x-trace-id").?);
+    try std.testing.expectEqualStrings("dark", req.cookie("theme").?);
+}
+
+test "Request common header cache preserves first-match semantics" {
+    const headers = [_]HeaderPair{
+        .{ .name = "content-type", .value = "text/plain" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Cookie", .value = "session=first" },
+        .{ .name = "cookie", .value = "session=second" },
+    };
+    const req = Request.init(std.testing.allocator, "GET", "/items?limit=1", &headers, "");
+
+    try std.testing.expectEqualStrings("/items", req.path);
+    try std.testing.expectEqualStrings("limit=1", req.query_string);
+    try std.testing.expectEqualStrings("text/plain", req.header("CONTENT-TYPE").?);
+    try std.testing.expectEqualStrings("first", req.cookie("session").?);
+}
+
+test "Request common headers fall back for struct literals without cache" {
+    const headers = [_]HeaderPair{
+        .{ .name = "Authorization", .value = "Bearer literal" },
+        .{ .name = "Cookie", .value = "session=literal" },
+    };
+    const req: Request = .{
+        .allocator = std.testing.allocator,
+        .method = "GET",
+        .target = "/",
+        .path = "/",
+        .query_string = "",
+        .headers = &headers,
+    };
+
+    try std.testing.expectEqualStrings("Bearer literal", req.header("authorization").?);
+    try std.testing.expectEqualStrings("literal", req.cookie("session").?);
+}

--- a/src/response.zig
+++ b/src/response.zig
@@ -367,6 +367,58 @@ pub const SseWriter = struct {
         data: []const u8,
         id: ?[]const u8,
     ) !void {
+        if (try self.eventBuffered(name, data, id)) return;
+        try self.eventSlow(name, data, id);
+    }
+
+    fn eventBuffered(
+        self: *SseWriter,
+        name: ?[]const u8,
+        data: []const u8,
+        id: ?[]const u8,
+    ) !bool {
+        var buf: [1024]u8 = undefined;
+        var len: usize = 0;
+
+        if (id) |value| {
+            if (!appendSseBytes(&buf, &len, "id: ") or
+                !appendSseBytes(&buf, &len, value) or
+                !appendSseBytes(&buf, &len, "\n"))
+            {
+                return false;
+            }
+        }
+        if (name) |value| {
+            if (!appendSseBytes(&buf, &len, "event: ") or
+                !appendSseBytes(&buf, &len, value) or
+                !appendSseBytes(&buf, &len, "\n"))
+            {
+                return false;
+            }
+        }
+
+        var lines = std.mem.splitScalar(u8, data, '\n');
+        while (lines.next()) |line| {
+            if (!appendSseBytes(&buf, &len, "data: ") or
+                !appendSseBytes(&buf, &len, line) or
+                !appendSseBytes(&buf, &len, "\n"))
+            {
+                return false;
+            }
+        }
+        if (!appendSseBytes(&buf, &len, "\n")) return false;
+
+        try self.ctx.write(buf[0..len]);
+        try self.ctx.flush();
+        return true;
+    }
+
+    fn eventSlow(
+        self: *SseWriter,
+        name: ?[]const u8,
+        data: []const u8,
+        id: ?[]const u8,
+    ) !void {
         if (id) |value| {
             try self.ctx.write("id: ");
             try self.ctx.write(value);
@@ -402,6 +454,13 @@ pub const SseWriter = struct {
         try self.ctx.flush();
     }
 };
+
+fn appendSseBytes(buf: []u8, len: *usize, bytes: []const u8) bool {
+    if (len.* + bytes.len > buf.len) return false;
+    @memcpy(buf[len.*..][0..bytes.len], bytes);
+    len.* += bytes.len;
+    return true;
+}
 
 pub fn jsonError(
     allocator: std.mem.Allocator,

--- a/src/root.zig
+++ b/src/root.zig
@@ -249,6 +249,42 @@ test "typed routes return DHI-backed validation errors" {
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "ValidationFailed") != null);
 }
 
+test "typed routes parse and validate JSON bodies" {
+    const allocator = std.testing.allocator;
+    var api = try NanoAPI.init(allocator, .{});
+    defer api.deinit();
+
+    const BodyModel = struct {
+        user_id: i64,
+        active: bool,
+    };
+    const Handler = struct {
+        fn postUser(ctx: typed.ContextWithBody(typed.Empty, typed.Empty, BodyModel)) anyerror!Response {
+            const body = try std.fmt.allocPrint(
+                ctx.raw.allocator,
+                "{{\"user_id\":{d},\"active\":{s}}}",
+                .{ ctx.body.user_id, if (ctx.body.active) "true" else "false" },
+            );
+            return response.Response.fromOwnedBody(ctx.raw.allocator, body, .{ .media_type = "application/json" });
+        }
+    };
+
+    try api.postTypedBody(typed.Empty, typed.Empty, BodyModel, "/typed-body", Handler.postUser, .{});
+
+    var req = Request.init(allocator, "POST", "/typed-body", &.{}, "{\"user_id\":42,\"active\":true}");
+    var resp = try api.handle(&req);
+    defer resp.deinit();
+
+    try std.testing.expectEqual(@as(u16, status.HTTP_200_OK), resp.status_code);
+    try std.testing.expectEqualStrings("{\"user_id\":42,\"active\":true}", resp.body);
+
+    var bad_req = Request.init(allocator, "POST", "/typed-body", &.{}, "{\"user_id\":\"bad\",\"active\":true}");
+    var bad_resp = try api.handle(&bad_req);
+    defer bad_resp.deinit();
+
+    try std.testing.expectEqual(@as(u16, status.HTTP_422_UNPROCESSABLE_ENTITY), bad_resp.status_code);
+}
+
 test {
     _ = core;
     _ = app;

--- a/src/routing.zig
+++ b/src/routing.zig
@@ -40,6 +40,32 @@ const ExactRoute = struct {
     index: usize,
 };
 
+const ExactRouteKey = struct {
+    method: []const u8,
+    path: []const u8,
+};
+
+const ExactRouteContext = struct {
+    pub fn hash(_: @This(), key: ExactRouteKey) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        hasher.update(key.method);
+        hasher.update(&.{0});
+        hasher.update(key.path);
+        return hasher.final();
+    }
+
+    pub fn eql(_: @This(), a: ExactRouteKey, b: ExactRouteKey) bool {
+        return std.mem.eql(u8, a.method, b.method) and std.mem.eql(u8, a.path, b.path);
+    }
+};
+
+const ExactRouteMap = std.HashMapUnmanaged(
+    ExactRouteKey,
+    usize,
+    ExactRouteContext,
+    std.hash_map.default_max_load_percentage,
+);
+
 pub const APIRouter = struct {
     allocator: std.mem.Allocator,
     prefix: []const u8,
@@ -47,6 +73,8 @@ pub const APIRouter = struct {
     core_router: core.Router,
     routes_list: std.ArrayList(RouteDefinition) = .empty,
     exact_routes: std.ArrayList(ExactRoute) = .empty,
+    exact_route_map: ExactRouteMap = .empty,
+    exact_method_mask: u8 = 0,
     root_get_index: ?usize = null,
 
     pub fn init(allocator: std.mem.Allocator, router_options: RouterOptions) !APIRouter {
@@ -64,6 +92,7 @@ pub const APIRouter = struct {
     }
 
     pub fn deinit(self: *APIRouter) void {
+        self.exact_route_map.deinit(self.allocator);
         for (self.routes_list.items) |*route_def| route_def.deinit(self.allocator);
         self.exact_routes.deinit(self.allocator);
         self.routes_list.deinit(self.allocator);
@@ -138,9 +167,10 @@ pub const APIRouter = struct {
             }
         }
 
-        for (self.exact_routes.items) |exact| {
-            if (std.mem.eql(u8, req.method, exact.method) and std.mem.eql(u8, req.path, exact.path)) {
-                return self.routes_list.items[exact.index].handler(req);
+        const exact_method_mask = self.exact_method_mask;
+        if (exact_method_mask != 0 and (exact_method_mask & methodMaskBit(req.method)) != 0) {
+            if (self.exact_route_map.getContext(.{ .method = req.method, .path = req.path }, .{})) |index| {
+                return self.routes_list.items[index].handler(req);
             }
         }
 
@@ -192,25 +222,59 @@ pub const APIRouter = struct {
             .options = owned_options,
         };
 
+        const is_root_get = std.mem.eql(u8, owned_method, "GET") and std.mem.eql(u8, full_path, "/");
+        const is_exact_non_root = !is_root_get and isExactPath(full_path);
+        if (is_exact_non_root) {
+            try self.exact_routes.ensureUnusedCapacity(self.allocator, 1);
+            try self.exact_route_map.ensureUnusedCapacityContext(self.allocator, 1, .{});
+        }
+
         try self.routes_list.append(self.allocator, route_def);
         errdefer _ = self.routes_list.pop();
 
-        if (std.mem.eql(u8, owned_method, "GET") and std.mem.eql(u8, full_path, "/")) {
+        try self.core_router.addRoute(method, full_path, key);
+
+        if (is_root_get) {
             self.root_get_index = index;
-        } else if (isExactPath(full_path)) {
-            try self.exact_routes.append(self.allocator, .{
+        } else if (is_exact_non_root) {
+            const exact_key = ExactRouteKey{ .method = owned_method, .path = full_path };
+            self.exact_routes.appendAssumeCapacity(.{
                 .method = owned_method,
                 .path = full_path,
                 .index = index,
             });
+            const gop = self.exact_route_map.getOrPutAssumeCapacityContext(exact_key, .{});
+            if (!gop.found_existing) {
+                gop.value_ptr.* = index;
+            }
+            self.exact_method_mask |= methodMaskBit(owned_method);
         }
-
-        try self.core_router.addRoute(method, full_path, key);
     }
 };
 
 fn isExactPath(path: []const u8) bool {
     return std.mem.indexOfAny(u8, path, "{*") == null;
+}
+
+fn methodMaskBit(method: []const u8) u8 {
+    return @as(u8, 1) << methodSlot(method);
+}
+
+fn methodSlot(method: []const u8) u3 {
+    if (method.len < 3) return 7;
+    return switch (method[0]) {
+        'G' => if (method.len == 3 and method[1] == 'E' and method[2] == 'T') 0 else 7,
+        'P' => switch (method.len) {
+            3 => if (method[1] == 'U' and method[2] == 'T') 2 else 7,
+            4 => if (method[1] == 'O' and method[2] == 'S' and method[3] == 'T') 1 else 7,
+            5 => if (method[1] == 'A' and method[2] == 'T' and method[3] == 'C' and method[4] == 'H') 4 else 7,
+            else => 7,
+        },
+        'D' => if (method.len == 6 and std.mem.eql(u8, method, "DELETE")) 3 else 7,
+        'H' => if (method.len == 4 and std.mem.eql(u8, method, "HEAD")) 5 else 7,
+        'O' => if (method.len == 7 and std.mem.eql(u8, method, "OPTIONS")) 6 else 7,
+        else => 7,
+    };
 }
 
 fn routeKeyForIndex(allocator: std.mem.Allocator, index: usize) ![]u8 {
@@ -384,4 +448,31 @@ fn joinPath(allocator: std.mem.Allocator, prefix: []const u8, path: []const u8) 
         return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ prefix, path });
     }
     return try std.fmt.allocPrint(allocator, "{s}{s}", .{ prefix, path });
+}
+
+fn propfindHandler(req: *request.Request) anyerror!response.Response {
+    return response.Response.fromStaticBody(req.allocator, "propfind", .{ .media_type = "text/plain" });
+}
+
+fn reportHandler(req: *request.Request) anyerror!response.Response {
+    return response.Response.fromStaticBody(req.allocator, "report", .{ .media_type = "text/plain" });
+}
+
+test "APIRouter exact static dispatch keeps custom methods distinct" {
+    const allocator = std.testing.allocator;
+    var router = try APIRouter.init(allocator, .{});
+    defer router.deinit();
+
+    try router.route("PROPFIND", "/resource", propfindHandler, .{});
+    try router.route("REPORT", "/resource", reportHandler, .{});
+
+    var propfind_req = request.Request.init(allocator, "PROPFIND", "/resource", &.{}, "");
+    var propfind_res = try router.handle(&propfind_req);
+    defer propfind_res.deinit();
+    try std.testing.expectEqualStrings("propfind", propfind_res.body);
+
+    var report_req = request.Request.init(allocator, "REPORT", "/resource", &.{}, "");
+    var report_res = try router.handle(&report_req);
+    defer report_res.deinit();
+    try std.testing.expectEqualStrings("report", report_res.body);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -186,7 +186,7 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
         };
         defer body.deinit(server.allocator);
 
-        var req = request.Request.initParts(
+        var req = request.Request.initPartsCached(
             server.allocator,
             parsed.method,
             parsed.target,
@@ -194,6 +194,7 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
             parsed.query_string,
             parsed.headers,
             body.bytes,
+            parsed.header_cache,
         );
 
         var res = server.app.handle(&req) catch {
@@ -253,7 +254,7 @@ const Connection = struct {
         };
         defer body.deinit(self.server.allocator);
 
-        var req = request.Request.initParts(
+        var req = request.Request.initPartsCached(
             self.server.allocator,
             parsed.method,
             parsed.target,
@@ -261,6 +262,7 @@ const Connection = struct {
             parsed.query_string,
             parsed.headers,
             body.bytes,
+            parsed.header_cache,
         );
 
         var res = self.server.app.handle(&req) catch {
@@ -280,6 +282,7 @@ const ParsedRequest = struct {
     path: []const u8,
     query_string: []const u8,
     headers: []const request.HeaderPair,
+    header_cache: request.Request.HeaderCache,
     body: []const u8,
     content_length: usize,
     keep_alive: bool,
@@ -303,6 +306,7 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
     var keep_alive = std.mem.eql(u8, version, "HTTP/1.1");
     var send_keep_alive_header = false;
     var header_count: usize = 0;
+    var header_cache = request.Request.HeaderCache.initForBuffer(headers_buf);
     var content_length: usize = 0;
     var pos = first_line_end + 2;
     var body: []const u8 = "";
@@ -335,6 +339,7 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
         const value = trimHeaderWhitespace(buf[colon_pos + 1 .. line_end]);
 
         headers_buf[header_count] = .{ .name = name, .value = value };
+        header_cache.observe(name, header_count);
         header_count += 1;
 
         if (std.ascii.eqlIgnoreCase(name, "connection")) {
@@ -348,12 +353,16 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
         }
     }
 
+    const headers = headers_buf[0..header_count];
+    header_cache.finish(headers);
+
     return .{
         .method = method,
         .target = target,
         .path = path,
         .query_string = query_string,
-        .headers = headers_buf[0..header_count],
+        .headers = headers,
+        .header_cache = header_cache,
         .body = if (body.len > content_length) body[0..content_length] else body,
         .content_length = content_length,
         .keep_alive = keep_alive,
@@ -475,6 +484,16 @@ fn configureAcceptedSocket(fd: c.fd_t) void {
             fd,
             c.SOL.SOCKET,
             c.SO.NOSIGPIPE,
+            &enabled,
+            @sizeOf(@TypeOf(enabled)),
+        );
+    }
+
+    if (@hasDecl(c, "TCP") and @hasDecl(c.TCP, "NODELAY") and @hasDecl(c, "IPPROTO") and @hasDecl(c.IPPROTO, "TCP")) {
+        _ = c.setsockopt(
+            fd,
+            c.IPPROTO.TCP,
+            c.TCP.NODELAY,
             &enabled,
             @sizeOf(@TypeOf(enabled)),
         );
@@ -719,9 +738,8 @@ fn chunkedWrite(sink: *anyopaque, bytes: []const u8) !void {
     const chunked: *ChunkedSink = @ptrCast(@alignCast(sink));
     var header: [32]u8 = undefined;
     const header_bytes = try std.fmt.bufPrint(&header, "{x}\r\n", .{bytes.len});
-    try sendAll(chunked.fd, header_bytes);
-    try sendAll(chunked.fd, bytes);
-    try sendAll(chunked.fd, "\r\n");
+    const parts = [_][]const u8{ header_bytes, bytes, "\r\n" };
+    try sendAllParts(chunked.fd, &parts);
 }
 
 fn chunkedFlush(sink: *anyopaque) !void {

--- a/src/server.zig
+++ b/src/server.zig
@@ -582,6 +582,23 @@ fn canUseFastJsonBytes(res: *const response.Response, keep_alive: bool, send_kee
 }
 
 fn sendFastJsonBytes(fd: c.fd_t, body: []const u8) !void {
+    if (comptime @hasDecl(c.SO, "NOSIGPIPE")) {
+        return sendFastJsonBytesVectored(fd, body);
+    }
+    return sendFastJsonBytesBuffered(fd, body);
+}
+
+fn sendFastJsonBytesVectored(fd: c.fd_t, body: []const u8) !void {
+    var len_buf: [20]u8 = undefined;
+    const len_bytes = len_buf[0..appendDecimal(&len_buf, body.len)];
+
+    const prefix = "HTTP/1.1 200 OK\r\nContent-Length: ";
+    const middle = "\r\nContent-Type: application/json\r\n\r\n";
+    const parts = [_][]const u8{ prefix, len_bytes, middle, body };
+    try sendAllParts(fd, &parts);
+}
+
+fn sendFastJsonBytesBuffered(fd: c.fd_t, body: []const u8) !void {
     var buf: [1024]u8 = undefined;
     var len: usize = 0;
 
@@ -607,6 +624,55 @@ fn sendFastJsonBytes(fd: c.fd_t, body: []const u8) !void {
     len += body.len;
 
     try sendAll(fd, buf[0..len]);
+}
+
+fn sendAllParts(fd: c.fd_t, parts: []const []const u8) !void {
+    var iovecs: [8]posix.iovec_const = undefined;
+    var iov_count: usize = 0;
+    for (parts) |part| {
+        if (part.len == 0) continue;
+        iovecs[iov_count] = .{ .base = part.ptr, .len = part.len };
+        iov_count += 1;
+    }
+    if (iov_count == 0) return;
+
+    var index: usize = 0;
+    var offset: usize = 0;
+    while (index < iov_count) {
+        var active: [8]posix.iovec_const = undefined;
+        active[0] = .{
+            .base = iovecs[index].base + offset,
+            .len = iovecs[index].len - offset,
+        };
+        var active_count: usize = 1;
+        var src = index + 1;
+        while (src < iov_count) : (src += 1) {
+            active[active_count] = iovecs[src];
+            active_count += 1;
+        }
+
+        const n = c.writev(fd, &active, @intCast(active_count));
+        switch (c.errno(n)) {
+            .SUCCESS => {
+                if (n == 0) return error.ConnectionClosed;
+                var advanced: usize = @intCast(n);
+                while (advanced > 0) {
+                    const remaining = iovecs[index].len - offset;
+                    if (advanced < remaining) {
+                        offset += advanced;
+                        break;
+                    }
+                    advanced -= remaining;
+                    index += 1;
+                    offset = 0;
+                    if (index == iov_count) break;
+                }
+            },
+            .INTR => continue,
+            .AGAIN => continue,
+            else => |err| return errnoError(err),
+        }
+    }
 }
 
 fn appendDecimal(out: []u8, value: usize) usize {

--- a/src/server.zig
+++ b/src/server.zig
@@ -773,6 +773,61 @@ fn sendFileBody(fd: c.fd_t, path: []const u8, file_size: u64) !void {
     const file_fd = try posix.openat(c.AT.FDCWD, path, .{}, 0);
     defer _ = close(file_fd);
 
+    if (comptime hasSendfile()) {
+        return sendFileBodyZeroCopy(fd, file_fd, file_size) catch |err| switch (err) {
+            error.Unexpected => sendFileBodyBuffered(fd, file_fd, file_size),
+            else => err,
+        };
+    }
+    return sendFileBodyBuffered(fd, file_fd, file_size);
+}
+
+fn hasSendfile() bool {
+    return switch (builtin.os.tag) {
+        .driverkit, .ios, .linux, .maccatalyst, .macos, .tvos, .visionos, .watchos => true,
+        else => false,
+    };
+}
+
+fn sendFileBodyZeroCopy(socket_fd: c.fd_t, file_fd: c.fd_t, file_size: u64) !void {
+    switch (builtin.os.tag) {
+        .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos => {
+            var offset: c.off_t = 0;
+            var remaining = std.math.cast(c.off_t, file_size) orelse return error.Unexpected;
+            while (remaining > 0) {
+                var sent = remaining;
+                const rc = c.sendfile(file_fd, socket_fd, offset, &sent, null, 0);
+                if (sent > 0) {
+                    offset += sent;
+                    remaining -= sent;
+                }
+                switch (c.errno(rc)) {
+                    .SUCCESS => {},
+                    .INTR, .AGAIN => continue,
+                    else => |err| return errnoError(err),
+                }
+            }
+        },
+        .linux => {
+            var offset: c.off_t = 0;
+            var remaining = std.math.cast(usize, file_size) orelse return error.Unexpected;
+            while (remaining > 0) {
+                const n = c.sendfile(socket_fd, file_fd, &offset, remaining);
+                switch (c.errno(n)) {
+                    .SUCCESS => {
+                        if (n == 0) return error.ConnectionClosed;
+                        remaining -= @intCast(n);
+                    },
+                    .INTR, .AGAIN => continue,
+                    else => |err| return errnoError(err),
+                }
+            }
+        },
+        else => unreachable,
+    }
+}
+
+fn sendFileBodyBuffered(fd: c.fd_t, file_fd: c.fd_t, file_size: u64) !void {
     var buf: [16 * 1024]u8 = undefined;
     var remaining = file_size;
     while (remaining > 0) {

--- a/src/server.zig
+++ b/src/server.zig
@@ -18,6 +18,8 @@ pub const Options = struct {
     read_buffer_size: usize = 16 * 1024,
     max_headers: usize = 64,
     runtime: Runtime = .auto,
+    /// Number of event-loop workers. 0 means one worker per logical CPU.
+    worker_threads: usize = 0,
 };
 
 pub const Runtime = enum {
@@ -67,7 +69,7 @@ pub const Server = struct {
     }
 
     fn listenAndServeThreaded(self: *Server) !void {
-        self.listen_fd = try createListenSocket(self.options);
+        self.listen_fd = try createListenSocket(self.options, false);
 
         while (true) {
             const fd = c.accept(self.listen_fd, null, null);
@@ -88,8 +90,26 @@ pub const Server = struct {
     }
 
     fn listenAndServeEventLoop(self: *Server) !void {
-        self.listen_fd = try createListenSocket(self.options);
+        const worker_count = effectiveWorkerCount(self.options.worker_threads);
+        if (worker_count > 1) return self.listenAndServeEventLoopWorkers(worker_count);
 
+        self.listen_fd = try createListenSocket(self.options, false);
+        return self.runEventLoop(self.listen_fd);
+    }
+
+    fn listenAndServeEventLoopWorkers(self: *Server, worker_count: usize) !void {
+        var worker_index: usize = 1;
+        while (worker_index < worker_count) : (worker_index += 1) {
+            const thread = try std.Thread.spawn(.{}, eventLoopWorker, .{ self, worker_index });
+            thread.detach();
+        }
+
+        const listen_fd = try createListenSocket(self.options, true);
+        defer _ = close(listen_fd);
+        try self.runEventLoop(listen_fd);
+    }
+
+    fn runEventLoop(self: *Server, listen_fd: c.fd_t) !void {
         const kq = c.kqueue();
         switch (c.errno(kq)) {
             .SUCCESS => {},
@@ -97,7 +117,7 @@ pub const Server = struct {
         }
         defer _ = close(kq);
 
-        try registerRead(kq, self.listen_fd, 0);
+        try registerRead(kq, listen_fd, 0);
 
         var connections = std.AutoHashMap(c.fd_t, *Connection).init(self.allocator);
         defer {
@@ -116,8 +136,8 @@ pub const Server = struct {
             }
 
             for (events[0..@intCast(n)]) |ev| {
-                if (ev.ident == @as(usize, @intCast(self.listen_fd))) {
-                    const fd = c.accept(self.listen_fd, null, null);
+                if (ev.ident == @as(usize, @intCast(listen_fd))) {
+                    const fd = c.accept(listen_fd, null, null);
                     switch (c.errno(fd)) {
                         .SUCCESS => {},
                         .INTR, .AGAIN => continue,
@@ -156,6 +176,27 @@ pub const Server = struct {
         }
     }
 };
+
+fn eventLoopWorker(server: *Server, worker_index: usize) void {
+    const listen_fd = createListenSocket(server.options, true) catch |err| {
+        if (builtin.mode == .Debug) {
+            std.debug.print("event-loop worker {d} failed to listen: {t}\n", .{ worker_index, err });
+        }
+        return;
+    };
+    defer _ = close(listen_fd);
+
+    server.runEventLoop(listen_fd) catch |err| {
+        if (builtin.mode == .Debug) {
+            std.debug.print("event-loop worker {d} stopped: {t}\n", .{ worker_index, err });
+        }
+    };
+}
+
+fn effectiveWorkerCount(configured: usize) usize {
+    if (configured != 0) return @max(configured, 1);
+    return @max(std.Thread.getCpuCount() catch 1, 1);
+}
 
 pub fn serve(app: *app_mod.App, allocator: std.mem.Allocator, options: Options) !void {
     var server = Server.init(app, allocator, options);
@@ -466,7 +507,7 @@ fn readFullBody(
     return .{ .bytes = body, .owned = true };
 }
 
-fn createListenSocket(options: Options) !c.fd_t {
+fn createListenSocket(options: Options, reuse_port: bool) !c.fd_t {
     const fd = socket(c.AF.INET, c.SOCK.STREAM, 0);
     switch (c.errno(fd)) {
         .SUCCESS => {},
@@ -482,6 +523,16 @@ fn createListenSocket(options: Options) !c.fd_t {
         &reuse,
         @sizeOf(@TypeOf(reuse)),
     );
+
+    if (reuse_port and @hasDecl(c.SO, "REUSEPORT")) {
+        _ = c.setsockopt(
+            fd,
+            c.SOL.SOCKET,
+            c.SO.REUSEPORT,
+            &reuse,
+            @sizeOf(@TypeOf(reuse)),
+        );
+    }
 
     if (@hasDecl(c.SO, "NOSIGPIPE")) {
         var no_sigpipe: c_int = 1;

--- a/src/server.zig
+++ b/src/server.zig
@@ -166,19 +166,26 @@ pub fn serve(app: *app_mod.App, allocator: std.mem.Allocator, options: Options) 
 fn handleConnection(server: *Server, fd: c.fd_t) void {
     defer _ = close(fd);
 
-    const buf = server.allocator.alloc(u8, server.options.read_buffer_size) catch return;
-    defer server.allocator.free(buf);
+    var input = InputBuffer{
+        .buf = server.allocator.alloc(u8, server.options.read_buffer_size) catch return,
+    };
+    defer server.allocator.free(input.buf);
 
     const headers = server.allocator.alloc(request.HeaderPair, server.options.max_headers) catch return;
     defer server.allocator.free(headers);
 
-    while (true) {
-        const n = recvOnce(fd, buf) catch return;
-        if (n == 0) return;
+    if ((input.readAppend(fd) catch return) == false) return;
 
-        const parsed = parseRequestHead(buf[0..n], headers) catch {
-            sendError(fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
-            return;
+    while (true) {
+        const parsed = parseRequestHead(input.bytes(), headers) catch |err| switch (err) {
+            error.IncompleteRequestHead => {
+                if ((input.readAppend(fd) catch return) == false) return;
+                continue;
+            },
+            else => {
+                sendError(fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
+                return;
+            },
         };
         const body = readFullBody(server.allocator, fd, parsed) catch {
             sendError(fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
@@ -205,13 +212,15 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
 
         sendResponse(fd, &res, parsed.keep_alive, parsed.send_keep_alive_header, std.mem.eql(u8, parsed.method, "HEAD")) catch return;
         if (!parsed.keep_alive) return;
+        input.consume(parsed.consumed_len);
+        if (input.len == 0 and (input.readAppend(fd) catch return) == false) return;
     }
 }
 
 const Connection = struct {
     server: *Server,
     fd: c.fd_t,
-    buf: []u8,
+    input: InputBuffer,
     headers: []request.HeaderPair,
 
     fn create(server: *Server, fd: c.fd_t) !*Connection {
@@ -227,7 +236,7 @@ const Connection = struct {
         conn.* = .{
             .server = server,
             .fd = fd,
-            .buf = buf,
+            .input = .{ .buf = buf },
             .headers = headers,
         };
         return conn;
@@ -236,43 +245,81 @@ const Connection = struct {
     fn deinit(self: *Connection) void {
         _ = close(self.fd);
         self.server.allocator.free(self.headers);
-        self.server.allocator.free(self.buf);
+        self.server.allocator.free(self.input.buf);
         self.server.allocator.destroy(self);
     }
 
     fn handleReadable(self: *Connection) bool {
-        const n = recvOnce(self.fd, self.buf) catch return false;
+        if ((self.input.readAppend(self.fd) catch return false) == false) return false;
+
+        while (self.input.len > 0) {
+            const parsed = parseRequestHead(self.input.bytes(), self.headers) catch |err| switch (err) {
+                error.IncompleteRequestHead => return true,
+                else => {
+                    sendError(self.fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
+                    return false;
+                },
+            };
+
+            if (parsed.body.len < parsed.content_length and parsed.body_start + parsed.content_length <= self.input.buf.len) {
+                return true;
+            }
+
+            const body = readFullBody(self.server.allocator, self.fd, parsed) catch {
+                sendError(self.fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
+                return false;
+            };
+            defer body.deinit(self.server.allocator);
+
+            var req = request.Request.initPartsCached(
+                self.server.allocator,
+                parsed.method,
+                parsed.target,
+                parsed.path,
+                parsed.query_string,
+                parsed.headers,
+                body.bytes,
+                parsed.header_cache,
+            );
+
+            var res = self.server.app.handle(&req) catch {
+                sendError(self.fd, status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal Server Error") catch {};
+                return false;
+            };
+            defer res.deinit();
+
+            sendResponse(self.fd, &res, parsed.keep_alive, parsed.send_keep_alive_header, std.mem.eql(u8, parsed.method, "HEAD")) catch return false;
+            if (!parsed.keep_alive) return false;
+            self.input.consume(parsed.consumed_len);
+        }
+        return true;
+    }
+};
+
+const InputBuffer = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn bytes(self: *const InputBuffer) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    fn readAppend(self: *InputBuffer, fd: c.fd_t) !bool {
+        if (self.len == self.buf.len) return error.RequestBufferFull;
+        const n = try recvOnce(fd, self.buf[self.len..]);
         if (n == 0) return false;
+        self.len += n;
+        return true;
+    }
 
-        const parsed = parseRequestHead(self.buf[0..n], self.headers) catch {
-            sendError(self.fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
-            return false;
-        };
-        const body = readFullBody(self.server.allocator, self.fd, parsed) catch {
-            sendError(self.fd, status.HTTP_400_BAD_REQUEST, "Bad Request") catch {};
-            return false;
-        };
-        defer body.deinit(self.server.allocator);
-
-        var req = request.Request.initPartsCached(
-            self.server.allocator,
-            parsed.method,
-            parsed.target,
-            parsed.path,
-            parsed.query_string,
-            parsed.headers,
-            body.bytes,
-            parsed.header_cache,
-        );
-
-        var res = self.server.app.handle(&req) catch {
-            sendError(self.fd, status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal Server Error") catch {};
-            return false;
-        };
-        defer res.deinit();
-
-        sendResponse(self.fd, &res, parsed.keep_alive, parsed.send_keep_alive_header, std.mem.eql(u8, parsed.method, "HEAD")) catch return false;
-        return parsed.keep_alive;
+    fn consume(self: *InputBuffer, amount: usize) void {
+        if (amount >= self.len) {
+            self.len = 0;
+            return;
+        }
+        const remaining = self.len - amount;
+        std.mem.copyForwards(u8, self.buf[0..remaining], self.buf[amount..self.len]);
+        self.len = remaining;
     }
 };
 
@@ -284,6 +331,8 @@ const ParsedRequest = struct {
     headers: []const request.HeaderPair,
     header_cache: request.Request.HeaderCache,
     body: []const u8,
+    body_start: usize,
+    consumed_len: usize,
     content_length: usize,
     keep_alive: bool,
     send_keep_alive_header: bool,
@@ -309,12 +358,14 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
     var header_cache = request.Request.HeaderCache.initForBuffer(headers_buf);
     var content_length: usize = 0;
     var pos = first_line_end + 2;
+    var body_start: usize = 0;
     var body: []const u8 = "";
 
     while (true) {
         if (pos + 1 >= buf.len) return error.IncompleteRequestHead;
         if (buf[pos] == '\r' and buf[pos + 1] == '\n') {
-            body = buf[pos + 2 ..];
+            body_start = pos + 2;
+            body = buf[body_start..];
             break;
         }
         if (header_count >= headers_buf.len) return error.TooManyHeaders;
@@ -355,6 +406,8 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
 
     const headers = headers_buf[0..header_count];
     header_cache.finish(headers);
+    const body_len = @min(body.len, content_length);
+    const consumed_len = if (body.len >= content_length) body_start + content_length else buf.len;
 
     return .{
         .method = method,
@@ -363,7 +416,9 @@ pub fn parseRequestHead(buf: []const u8, headers_buf: []request.HeaderPair) !Par
         .query_string = query_string,
         .headers = headers,
         .header_cache = header_cache,
-        .body = if (body.len > content_length) body[0..content_length] else body,
+        .body = body[0..body_len],
+        .body_start = body_start,
+        .consumed_len = consumed_len,
         .content_length = content_length,
         .keep_alive = keep_alive,
         .send_keep_alive_header = send_keep_alive_header,
@@ -857,4 +912,26 @@ test "parse HTTP request content length" {
     try std.testing.expectEqualStrings("POST", parsed.method);
     try std.testing.expectEqual(@as(usize, 5), parsed.content_length);
     try std.testing.expectEqualStrings("hello", parsed.body);
+}
+
+test "parse HTTP request preserves pipelined bytes after body" {
+    var headers: [8]request.HeaderPair = undefined;
+    const bytes =
+        "POST /upload HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello" ++
+        "GET /next HTTP/1.1\r\n\r\n";
+    const parsed = try parseRequestHead(bytes, &headers);
+
+    try std.testing.expectEqual(@as(usize, 5), parsed.content_length);
+    try std.testing.expectEqualStrings("hello", parsed.body);
+    try std.testing.expectEqualStrings("GET /next HTTP/1.1\r\n\r\n", bytes[parsed.consumed_len..]);
+}
+
+test "parse HTTP request consumes zero-body request before pipeline" {
+    var headers: [8]request.HeaderPair = undefined;
+    const bytes = "GET / HTTP/1.1\r\n\r\nGET /next HTTP/1.1\r\n\r\n";
+    const parsed = try parseRequestHead(bytes, &headers);
+
+    try std.testing.expectEqual(@as(usize, 0), parsed.content_length);
+    try std.testing.expectEqual(@as(usize, 0), parsed.body.len);
+    try std.testing.expectEqualStrings("GET /next HTTP/1.1\r\n\r\n", bytes[parsed.consumed_len..]);
 }

--- a/src/typed.zig
+++ b/src/typed.zig
@@ -122,24 +122,17 @@ fn parseStruct(comptime T: type, req: *const request.Request, comptime location:
     var result: T = undefined;
 
     inline for (@typeInfo(T).@"struct".fields) |field| {
-        const raw = switch (location) {
-            .path => req.pathParam(field.name),
-            .query => req.queryParam(field.name),
-            else => unreachable,
-        };
-
-        if (raw) |value| {
-            @field(result, field.name) = try parseFieldValue(field.type, req, field.name, value, location);
-        } else if (field.defaultValue()) |default| {
-            @field(result, field.name) = default;
-        } else if (comptime isOptional(field.type)) {
-            @field(result, field.name) = null;
-        } else {
-            return switch (location) {
-                .path => error.MissingRequiredPathParam,
-                .query => error.MissingRequiredQueryParam,
-                else => unreachable,
-            };
+        switch (try parseField(field.type, req, field.name, location)) {
+            .value => |value| @field(result, field.name) = value,
+            .missing => {
+                if (field.defaultValue()) |default| {
+                    @field(result, field.name) = default;
+                } else if (comptime isOptional(field.type)) {
+                    @field(result, field.name) = null;
+                } else {
+                    return missingRequiredError(location);
+                }
+            },
         }
     }
 
@@ -166,50 +159,111 @@ fn parseErrorResponse(allocator: std.mem.Allocator, err: anyerror) !response.Res
     );
 }
 
-fn parseFieldValue(
+fn ParsedField(comptime T: type) type {
+    return union(enum) {
+        missing,
+        value: T,
+    };
+}
+
+fn parseField(
     comptime T: type,
     req: *const request.Request,
     comptime name: []const u8,
-    raw: []const u8,
     comptime location: meta.Location,
-) ParseError!T {
-    if (location == .path and @typeInfo(T) == .int) {
-        const value = req.pathInt(name) orelse return error.UnsupportedParamType;
-        return std.math.cast(T, value) orelse error.UnsupportedParamType;
+) ParseError!ParsedField(T) {
+    switch (location) {
+        .path => {
+            if (comptime valueKind(T) == .int) {
+                return parsePathIntField(T, req, name);
+            }
+            const raw = req.pathParam(name) orelse return .missing;
+            return .{ .value = try parseValue(T, raw) };
+        },
+        .query => {
+            const raw = req.queryParam(name) orelse return .missing;
+            return .{ .value = try parseValue(T, raw) };
+        },
+        else => unreachable,
     }
-    return parseValue(T, raw);
+}
+
+fn parsePathIntField(comptime T: type, req: *const request.Request, comptime name: []const u8) ParseError!ParsedField(T) {
+    const params = req.path_params orelse return .missing;
+    for (params.entries()) |param| {
+        if (std.mem.eql(u8, param.key, name)) {
+            if (!param.has_int_value) return error.UnsupportedParamType;
+            const value = std.math.cast(T, param.int_value) orelse return error.UnsupportedParamType;
+            return .{ .value = value };
+        }
+    }
+    return .missing;
+}
+
+fn missingRequiredError(comptime location: meta.Location) ParseError {
+    return switch (location) {
+        .path => error.MissingRequiredPathParam,
+        .query => error.MissingRequiredQueryParam,
+        else => unreachable,
+    };
+}
+
+const ValueKind = enum {
+    bool,
+    int,
+    float,
+    optional,
+    string_slice,
+    unsupported,
+};
+
+fn valueKind(comptime T: type) ValueKind {
+    return switch (@typeInfo(T)) {
+        .bool => .bool,
+        .int => .int,
+        .float => .float,
+        .optional => .optional,
+        .pointer => |info| if (info.size == .slice and info.child == u8) .string_slice else .unsupported,
+        else => .unsupported,
+    };
+}
+
+fn optionalChild(comptime T: type) type {
+    return switch (@typeInfo(T)) {
+        .optional => |info| info.child,
+        else => @compileError("expected optional type"),
+    };
 }
 
 fn parseValue(comptime T: type, raw: []const u8) ParseError!T {
-    return switch (@typeInfo(T)) {
+    return switch (comptime valueKind(T)) {
         .bool => parseBool(raw),
         .int => std.fmt.parseInt(T, raw, 10) catch error.UnsupportedParamType,
         .float => std.fmt.parseFloat(T, raw) catch error.UnsupportedParamType,
-        .optional => |info| if (raw.len == 0) null else try parseValue(info.child, raw),
-        .pointer => |info| blk: {
-            if (info.size == .slice and info.child == u8) break :blk raw;
-            return error.UnsupportedParamType;
-        },
-        else => error.UnsupportedParamType,
+        .optional => if (raw.len == 0) null else try parseValue(optionalChild(T), raw),
+        .string_slice => raw,
+        .unsupported => error.UnsupportedParamType,
     };
 }
 
 fn parseBool(raw: []const u8) ParseError!bool {
-    if (std.mem.eql(u8, raw, "true") or std.mem.eql(u8, raw, "1")) return true;
-    if (std.mem.eql(u8, raw, "false") or std.mem.eql(u8, raw, "0")) return false;
-    if (std.ascii.eqlIgnoreCase(raw, "true") or
-        std.mem.eql(u8, raw, "1") or
-        std.ascii.eqlIgnoreCase(raw, "on") or
-        std.ascii.eqlIgnoreCase(raw, "yes"))
-    {
-        return true;
-    }
-    if (std.ascii.eqlIgnoreCase(raw, "false") or
-        std.mem.eql(u8, raw, "0") or
-        std.ascii.eqlIgnoreCase(raw, "off") or
-        std.ascii.eqlIgnoreCase(raw, "no"))
-    {
-        return false;
+    switch (raw.len) {
+        1 => switch (raw[0]) {
+            '1' => return true,
+            '0' => return false,
+            else => {},
+        },
+        2 => {
+            if (std.ascii.eqlIgnoreCase(raw, "on")) return true;
+            if (std.ascii.eqlIgnoreCase(raw, "no")) return false;
+        },
+        3 => {
+            if (std.ascii.eqlIgnoreCase(raw, "yes")) return true;
+            if (std.ascii.eqlIgnoreCase(raw, "off")) return false;
+        },
+        4 => if (std.ascii.eqlIgnoreCase(raw, "true")) return true,
+        5 => if (std.ascii.eqlIgnoreCase(raw, "false")) return false,
+        else => {},
     }
     return error.InvalidBool;
 }
@@ -228,13 +282,13 @@ fn makeParameter(
 }
 
 fn schemaType(comptime T: type) meta.SchemaType {
-    return switch (@typeInfo(T)) {
+    return switch (comptime valueKind(T)) {
         .bool => .boolean,
         .int => .integer,
         .float => .number,
-        .optional => |info| schemaType(info.child),
-        .pointer => |info| if (info.size == .slice and info.child == u8) .string else .any,
-        else => .any,
+        .optional => schemaType(optionalChild(T)),
+        .string_slice => .string,
+        .unsupported => .any,
     };
 }
 
@@ -254,4 +308,43 @@ fn assertStruct(comptime T: type) void {
     if (@typeInfo(T) != .@"struct") {
         @compileError("typed path/query parameter declarations must be structs, got " ++ @typeName(T));
     }
+}
+
+test "typed bool parser accepts supported forms" {
+    const cases = [_]struct {
+        raw: []const u8,
+        value: bool,
+    }{
+        .{ .raw = "true", .value = true },
+        .{ .raw = "TRUE", .value = true },
+        .{ .raw = "1", .value = true },
+        .{ .raw = "on", .value = true },
+        .{ .raw = "YES", .value = true },
+        .{ .raw = "false", .value = false },
+        .{ .raw = "FALSE", .value = false },
+        .{ .raw = "0", .value = false },
+        .{ .raw = "off", .value = false },
+        .{ .raw = "NO", .value = false },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(case.value, try parseValue(bool, case.raw));
+    }
+    try std.testing.expectError(error.InvalidBool, parseValue(bool, "truthy"));
+}
+
+test "typed path integer parser uses route param cache" {
+    const core = @import("turboapi-core");
+
+    var req = request.Request.init(std.testing.allocator, "GET", "/items/42", &.{}, "");
+    var params = core.RouteParams{};
+    params.put("id", "42");
+    req.setPathParams(&params);
+
+    const PathParams = struct {
+        id: i8,
+    };
+
+    const parsed = try parsePath(PathParams, &req);
+    try std.testing.expectEqual(@as(i8, 42), parsed.id);
 }

--- a/src/typed.zig
+++ b/src/typed.zig
@@ -29,8 +29,25 @@ pub fn Context(comptime PathParams: type, comptime QueryParams: type) type {
     };
 }
 
+pub fn ContextWithBody(comptime PathParams: type, comptime QueryParams: type, comptime BodyModel: type) type {
+    assertStruct(PathParams);
+    assertStruct(QueryParams);
+    assertStruct(BodyModel);
+
+    return struct {
+        raw: *request.Request,
+        path: PathParams,
+        query: QueryParams,
+        body: BodyModel,
+    };
+}
+
 pub fn Handler(comptime PathParams: type, comptime QueryParams: type) type {
     return *const fn (Context(PathParams, QueryParams)) anyerror!response.Response;
+}
+
+pub fn HandlerWithBody(comptime PathParams: type, comptime QueryParams: type, comptime BodyModel: type) type {
+    return *const fn (ContextWithBody(PathParams, QueryParams, BodyModel)) anyerror!response.Response;
 }
 
 pub fn adapt(
@@ -55,6 +72,33 @@ pub fn adapt(
     }.call;
 }
 
+pub fn adaptWithBody(
+    comptime PathParams: type,
+    comptime QueryParams: type,
+    comptime BodyModel: type,
+    comptime handler: HandlerWithBody(PathParams, QueryParams, BodyModel),
+) routing.Handler {
+    return struct {
+        fn call(req: *request.Request) anyerror!response.Response {
+            const path = parsePath(PathParams, req) catch |err| {
+                return parseErrorResponse(req.allocator, err);
+            };
+            const query = parseQuery(QueryParams, req) catch |err| {
+                return parseErrorResponse(req.allocator, err);
+            };
+            const body = parseBody(BodyModel, req) catch |err| {
+                return parseErrorResponse(req.allocator, err);
+            };
+            return handler(.{
+                .raw = req,
+                .path = path,
+                .query = query,
+                .body = body,
+            });
+        }
+    }.call;
+}
+
 pub fn get(
     api: anytype,
     comptime PathParams: type,
@@ -72,6 +116,24 @@ pub fn get(
     try api.get(path, adapt(PathParams, QueryParams, handler), options);
 }
 
+pub fn postWithBody(
+    api: anytype,
+    comptime PathParams: type,
+    comptime QueryParams: type,
+    comptime BodyModel: type,
+    path: []const u8,
+    comptime handler: HandlerWithBody(PathParams, QueryParams, BodyModel),
+    route_options: meta.RouteOptions,
+) !void {
+    const allocator = api.allocator;
+    const generated = try allocParameters(allocator, PathParams, QueryParams);
+    defer freeParameters(allocator, generated);
+
+    var options = route_options;
+    options.parameters = generated;
+    try api.post(path, adaptWithBody(PathParams, QueryParams, BodyModel, handler), options);
+}
+
 pub fn parsePath(comptime T: type, req: *const request.Request) ParseError!T {
     assertStruct(T);
     const fields = @typeInfo(T).@"struct".fields;
@@ -84,6 +146,14 @@ pub fn parseQuery(comptime T: type, req: *const request.Request) ParseError!T {
     const fields = @typeInfo(T).@"struct".fields;
     if (comptime fields.len <= 1) return parseStruct(T, req, .query);
     return parseQueryStruct(T, req);
+}
+
+pub fn parseBody(comptime T: type, req: *const request.Request) ParseError!T {
+    assertStruct(T);
+    return dhi.parseAndValidate(T, req.body, req.allocator) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => error.ValidationFailed,
+    };
 }
 
 pub fn allocParameters(

--- a/src/typed.zig
+++ b/src/typed.zig
@@ -77,7 +77,10 @@ pub fn parsePath(comptime T: type, req: *const request.Request) ParseError!T {
 }
 
 pub fn parseQuery(comptime T: type, req: *const request.Request) ParseError!T {
-    return parseStruct(T, req, .query);
+    assertStruct(T);
+    const fields = @typeInfo(T).@"struct".fields;
+    if (comptime fields.len <= 1) return parseStruct(T, req, .query);
+    return parseQueryStruct(T, req);
 }
 
 pub fn allocParameters(
@@ -133,6 +136,58 @@ fn parseStruct(comptime T: type, req: *const request.Request, comptime location:
                     return missingRequiredError(location);
                 }
             },
+        }
+    }
+
+    if (comptime needsDhiValidation(T)) {
+        try validateParsed(T, result, req.allocator);
+    }
+    return result;
+}
+
+fn parseQueryStruct(comptime T: type, req: *const request.Request) ParseError!T {
+    assertStruct(T);
+
+    const fields = @typeInfo(T).@"struct".fields;
+    if (comptime fields.len == 0) return .{};
+
+    var result: T = undefined;
+    var seen = [_]bool{false} ** fields.len;
+
+    inline for (fields, 0..) |field, i| {
+        if (field.defaultValue()) |default| {
+            @field(result, field.name) = default;
+        } else if (comptime isOptional(field.type)) {
+            @field(result, field.name) = null;
+        } else {
+            seen[i] = false;
+        }
+    }
+
+    var pos: usize = 0;
+    while (pos < req.query_string.len) {
+        const pair_start = pos;
+        const pair_end = std.mem.indexOfScalarPos(u8, req.query_string, pair_start, '&') orelse req.query_string.len;
+        pos = if (pair_end < req.query_string.len) pair_end + 1 else req.query_string.len;
+
+        const pair = req.query_string[pair_start..pair_end];
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        const key = pair[0..eq];
+        const value = pair[eq + 1 ..];
+
+        var matched = false;
+        inline for (fields, 0..) |field, i| {
+            if (!matched and !seen[i] and std.mem.eql(u8, key, field.name)) {
+                @field(result, field.name) = try parseValue(field.type, value);
+                seen[i] = true;
+                matched = true;
+            }
+        }
+    }
+
+    inline for (fields, 0..) |field, i| {
+        if (!seen[i] and field.default_value_ptr == null and !isOptional(field.type)) {
+            return error.MissingRequiredQueryParam;
         }
     }
 
@@ -347,4 +402,19 @@ test "typed path integer parser uses route param cache" {
 
     const parsed = try parsePath(PathParams, &req);
     try std.testing.expectEqual(@as(i8, 42), parsed.id);
+}
+
+test "typed query parser uses first value and defaults" {
+    var req = request.Request.init(std.testing.allocator, "GET", "/items?verbose=true&limit=10&verbose=false", &.{}, "");
+
+    const QueryParams = struct {
+        verbose: bool = false,
+        limit: u8,
+        cursor: ?[]const u8 = null,
+    };
+
+    const parsed = try parseQuery(QueryParams, &req);
+    try std.testing.expect(parsed.verbose);
+    try std.testing.expectEqual(@as(u8, 10), parsed.limit);
+    try std.testing.expect(parsed.cursor == null);
 }

--- a/src/typed.zig
+++ b/src/typed.zig
@@ -73,7 +73,10 @@ pub fn get(
 }
 
 pub fn parsePath(comptime T: type, req: *const request.Request) ParseError!T {
-    return parseStruct(T, req, .path);
+    assertStruct(T);
+    const fields = @typeInfo(T).@"struct".fields;
+    if (comptime fields.len <= 1) return parseStruct(T, req, .path);
+    return parsePathStruct(T, req);
 }
 
 pub fn parseQuery(comptime T: type, req: *const request.Request) ParseError!T {
@@ -195,6 +198,57 @@ fn parseQueryStruct(comptime T: type, req: *const request.Request) ParseError!T 
         try validateParsed(T, result, req.allocator);
     }
     return result;
+}
+
+fn parsePathStruct(comptime T: type, req: *const request.Request) ParseError!T {
+    assertStruct(T);
+
+    const fields = @typeInfo(T).@"struct".fields;
+    if (comptime fields.len == 0) return .{};
+
+    var result: T = undefined;
+    var seen = [_]bool{false} ** fields.len;
+
+    inline for (fields, 0..) |field, i| {
+        if (field.defaultValue()) |default| {
+            @field(result, field.name) = default;
+        } else if (comptime isOptional(field.type)) {
+            @field(result, field.name) = null;
+        } else {
+            seen[i] = false;
+        }
+    }
+
+    const params = req.path_params orelse return error.MissingRequiredPathParam;
+    for (params.entries()) |param| {
+        var matched = false;
+        inline for (fields, 0..) |field, i| {
+            if (!matched and !seen[i] and std.mem.eql(u8, param.key, field.name)) {
+                @field(result, field.name) = try parsePathParamValue(field.type, param);
+                seen[i] = true;
+                matched = true;
+            }
+        }
+    }
+
+    inline for (fields, 0..) |field, i| {
+        if (!seen[i] and field.default_value_ptr == null and !isOptional(field.type)) {
+            return error.MissingRequiredPathParam;
+        }
+    }
+
+    if (comptime needsDhiValidation(T)) {
+        try validateParsed(T, result, req.allocator);
+    }
+    return result;
+}
+
+fn parsePathParamValue(comptime T: type, param: @import("turboapi-core").RouteParam) ParseError!T {
+    if (comptime valueKind(T) == .int) {
+        if (!param.has_int_value) return error.UnsupportedParamType;
+        return std.math.cast(T, param.int_value) orelse error.UnsupportedParamType;
+    }
+    return parseValue(T, param.value);
 }
 
 fn validateParsed(comptime T: type, value: T, allocator: std.mem.Allocator) ParseError!void {
@@ -402,6 +456,28 @@ test "typed path integer parser uses route param cache" {
 
     const parsed = try parsePath(PathParams, &req);
     try std.testing.expectEqual(@as(i8, 42), parsed.id);
+}
+
+test "typed path parser scans route params once for multiple fields" {
+    const core = @import("turboapi-core");
+
+    var req = request.Request.init(std.testing.allocator, "GET", "/orgs/7/users/42", &.{}, "");
+    var params = core.RouteParams{};
+    params.put("org_id", "7");
+    params.put("user_id", "42");
+    params.put("slug", "rach");
+    req.setPathParams(&params);
+
+    const PathParams = struct {
+        org_id: u8,
+        user_id: i16,
+        slug: []const u8,
+    };
+
+    const parsed = try parsePath(PathParams, &req);
+    try std.testing.expectEqual(@as(u8, 7), parsed.org_id);
+    try std.testing.expectEqual(@as(i16, 42), parsed.user_id);
+    try std.testing.expectEqualStrings("rach", parsed.slug);
 }
 
 test "typed query parser uses first value and defaults" {


### PR DESCRIPTION
## Summary
- add configurable kqueue event-loop worker count with auto logical-CPU mode
- wire worker count through the benchmark HTTP server and bench script
- update README with multicore runtime notes and current framework benchmark numbers

## Verification
- `zig build test`
- `zig build -Doptimize=ReleaseFast http-server -- 18210 event_loop 4 --check`
- `./scripts/check-dispatch-bench.sh`
- `git diff --check`

tests note: the suite prints the existing negative DHI validation message for `user_id`, but exits 0.
