### PR TITLE
refactor: decouple runtime from App via Dispatcher vtable (closes #11)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -184,6 +184,20 @@ pub const App = struct {
         return ctx.next();
     }
 
+    /// Build a `server.Dispatcher` vtable wired to this App. Use this when
+    /// driving the runtime via `server.serveGeneric(app.dispatcher(), ...)`
+    /// rather than the `App`-bound `serve()` wrapper. This is also what
+    /// non-`App` consumers (turboAPI, merjs) construct directly with their
+    /// own ctx + adapter functions.
+    pub fn dispatcher(self: *App) @import("server.zig").Dispatcher {
+        return .{
+            .ctx = @ptrCast(self),
+            .handle = appHandleAdapter,
+            .has_middleware = appHasMiddlewareAdapter,
+            .try_static_dispatch = appTryStaticDispatchAdapter,
+        };
+    }
+
     pub fn listenAndServe(self: *App, allocator: std.mem.Allocator, server_options: @import("server.zig").Options) !void {
         try @import("server.zig").serve(self, allocator, server_options);
     }
@@ -207,3 +221,18 @@ pub const App = struct {
         for (self.shutdown_handlers.items) |handler| try handler();
     }
 };
+
+fn appHandleAdapter(ctx: *anyopaque, req: *request.Request) anyerror!response.Response {
+    const self: *App = @ptrCast(@alignCast(ctx));
+    return self.handle(req);
+}
+
+fn appHasMiddlewareAdapter(ctx: *anyopaque) bool {
+    const self: *App = @ptrCast(@alignCast(ctx));
+    return self.middlewares.items.len != 0;
+}
+
+fn appTryStaticDispatchAdapter(ctx: *anyopaque, method: []const u8, path: []const u8) ?[]const u8 {
+    const self: *App = @ptrCast(@alignCast(ctx));
+    return self.router.tryStaticDispatch(method, path);
+}

--- a/src/io_uring.zig
+++ b/src/io_uring.zig
@@ -372,9 +372,10 @@ fn processRequests(conn: *IoConn) Action {
         var dispatched = false;
         static_dispatch: {
             if (parsed.content_length != 0) break :static_dispatch;
-            if (conn.server.app.middlewares.items.len != 0) break :static_dispatch;
+            if (conn.server.dispatcher.has_middleware(conn.server.dispatcher.ctx)) break :static_dispatch;
             if (parsed.is_head) break :static_dispatch;
-            const static_bytes = conn.server.app.router.tryStaticDispatch(parsed.method, parsed.path) orelse break :static_dispatch;
+            const try_static = conn.server.dispatcher.try_static_dispatch orelse break :static_dispatch;
+            const static_bytes = try_static(conn.server.dispatcher.ctx, parsed.method, parsed.path) orelse break :static_dispatch;
             if (!conn.appendStaticBytes(static_bytes)) {
                 // No room in write buffer — flush what we have and come back.
                 return .send_then_recv;
@@ -396,7 +397,7 @@ fn processRequests(conn: *IoConn) Action {
                 parsed.header_cache,
             );
 
-            var res = conn.server.app.handle(&req) catch {
+            var res = conn.server.dispatcher.handle(conn.server.dispatcher.ctx, &req) catch {
                 _ = conn.arena.reset(.retain_capacity);
                 if (conn.write_len > 0) return .send_then_close;
                 return .close;

--- a/src/server.zig
+++ b/src/server.zig
@@ -37,15 +37,38 @@ pub const Runtime = enum {
     io_uring,
 };
 
+/// Function the runtime calls to dispatch a parsed request to user code.
+/// `ctx` is the opaque pointer the dispatcher was registered with.
+pub const HandleFn = *const fn (ctx: *anyopaque, req: *request.Request) anyerror!response.Response;
+
+/// Optional fast path: returns pre-rendered HTTP response bytes for a static
+/// route, or null to fall back to the normal `handle()` call. Set to null on
+/// the dispatcher to disable the static-cache shortcut.
+pub const TryStaticDispatchFn = *const fn (ctx: *anyopaque, method: []const u8, path: []const u8) ?[]const u8;
+
+/// Returns true if the dispatcher has middleware registered. The runtime skips
+/// the static-cache shortcut when middleware is present so middlewares can run.
+pub const HasMiddlewareFn = *const fn (ctx: *anyopaque) bool;
+
+/// Vtable plugged into the runtime so non-`App` consumers (turboAPI's Python
+/// FFI dispatch, merjs' SSR dispatch) can drive the same accept loop, parser,
+/// and response writer that `App` uses internally.
+pub const Dispatcher = struct {
+    ctx: *anyopaque,
+    handle: HandleFn,
+    has_middleware: HasMiddlewareFn,
+    try_static_dispatch: ?TryStaticDispatchFn = null,
+};
+
 pub const Server = struct {
-    app: *app_mod.App,
+    dispatcher: Dispatcher,
     allocator: std.mem.Allocator,
     options: Options,
     listen_fd: c.fd_t = -1,
 
-    pub fn init(app: *app_mod.App, allocator: std.mem.Allocator, options: Options) Server {
+    pub fn init(dispatcher: Dispatcher, allocator: std.mem.Allocator, options: Options) Server {
         return .{
-            .app = app,
+            .dispatcher = dispatcher,
             .allocator = allocator,
             .options = options,
         };
@@ -237,7 +260,14 @@ fn effectiveRuntime(requested: Runtime) Runtime {
 }
 
 pub fn serve(app: *app_mod.App, allocator: std.mem.Allocator, options: Options) !void {
-    var server = Server.init(app, allocator, options);
+    return serveGeneric(app.dispatcher(), allocator, options);
+}
+
+/// Drive the runtime with any dispatcher — not just `App`. Use this from
+/// non-`App` consumers (turboAPI's Python FFI, merjs' SSR pipeline) by
+/// constructing a `Dispatcher` with your own ctx + adapter functions.
+pub fn serveGeneric(dispatcher: Dispatcher, allocator: std.mem.Allocator, options: Options) !void {
+    var server = Server.init(dispatcher, allocator, options);
     defer server.deinit();
     try server.listenAndServe();
 }
@@ -286,7 +316,7 @@ fn handleConnection(server: *Server, fd: c.fd_t) void {
             parsed.header_cache,
         );
 
-        var res = server.app.handle(&req) catch {
+        var res = server.dispatcher.handle(server.dispatcher.ctx, &req) catch {
             sendError(fd, status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal Server Error") catch {};
             return;
         };
@@ -436,9 +466,10 @@ const Connection = struct {
             // need to suppress the body).
             static_dispatch: {
                 if (parsed.content_length != 0) break :static_dispatch;
-                if (self.server.app.middlewares.items.len != 0) break :static_dispatch;
+                if (self.server.dispatcher.has_middleware(self.server.dispatcher.ctx)) break :static_dispatch;
                 if (parsed.is_head) break :static_dispatch;
-                const static_bytes = self.server.app.router.tryStaticDispatch(parsed.method, parsed.path) orelse break :static_dispatch;
+                const try_static = self.server.dispatcher.try_static_dispatch orelse break :static_dispatch;
+                const static_bytes = try_static(self.server.dispatcher.ctx, parsed.method, parsed.path) orelse break :static_dispatch;
                 self.appendStaticBytes(static_bytes) catch return false;
                 self.input.consume(parsed.consumed_len);
                 continue;
@@ -461,7 +492,7 @@ const Connection = struct {
                 parsed.header_cache,
             );
 
-            var res = self.server.app.handle(&req) catch {
+            var res = self.server.dispatcher.handle(self.server.dispatcher.ctx, &req) catch {
                 self.flushWrite() catch {};
                 sendError(self.fd, status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal Server Error") catch {};
                 return false;
@@ -525,7 +556,7 @@ const InputBuffer = struct {
     }
 };
 
-const ParsedRequest = struct {
+pub const ParsedRequest = struct {
     method: []const u8,
     target: []const u8,
     path: []const u8,


### PR DESCRIPTION
## Summary

Closes #11. Introduces \`server.Dispatcher\` so non-\`App\` consumers (turboAPI's Python FFI dispatch, merjs' SSR dispatch) can drive the same accept loop, HTTP/1.1 parser, and response writer that \`App\` uses internally.

Targeting \`codex/rust-framework-perf-pass\` rather than \`main\` because \`io_uring.zig\` lives on this branch — the dispatcher work needs to land where the runtime actually lives.

## What changed

- **\`src/server.zig\`** — Added \`Dispatcher\` / \`HandleFn\` / \`HasMiddlewareFn\` / \`TryStaticDispatchFn\` types. Replaced \`Server.app: *App\` with \`Server.dispatcher: Dispatcher\`. Rewrote the 4 reach-in sites (threaded dispatch, kqueue static-cache check, kqueue static-cache lookup, kqueue dispatch) to call through the vtable. Added \`serveGeneric(dispatcher, allocator, options)\`; kept \`serve(*App, ...)\` as a one-line back-compat wrapper. Promoted \`ParsedRequest\` to \`pub\`.
- **\`src/io_uring.zig\`** — Same treatment for the 3 reach-in sites (static-cache check, static-cache lookup, dispatch).
- **\`src/app.zig\`** — Added \`App.dispatcher()\` method that returns a \`Dispatcher\` vtable wired to the App, plus three free-function adapters (\`appHandleAdapter\`, \`appHasMiddlewareAdapter\`, \`appTryStaticDispatchAdapter\`).

Diff: 3 files, +73/-12. \`serve(*App)\` users see no change.

## Backwards compatibility

\`App.listenAndServe(allocator, options)\` and \`serve(app, allocator, options)\` are unchanged from a caller's perspective:

\`\`\`zig
// Before and after — identical:
try app.listenAndServe(allocator, .{ .port = 8080 });

// After — also possible (used by non-App consumers):
const dispatcher = my_dispatcher_struct.dispatcher();
try server.serveGeneric(dispatcher, allocator, .{ .port = 8080 });
\`\`\`

## Test plan

- [x] \`zig build test\` — 28/28 pass on macOS arm64, Zig 0.16.0
- [x] **Empirical proof from turboAPI** — a 68-line Zig binary in turboAPI's [\`feat/nanoapi-runtime-spike\`](https://github.com/justrach/turboAPI/tree/feat/nanoapi-runtime-spike/spike) branch constructs a \`Dispatcher\` with a custom \`SpikeContext\` (no \`App\`, no router, no typed routes, no OpenAPI), calls \`nanoapi.server.serveGeneric\`, and serves real HTTP:

\`\`\`
GET  /              → 200 "ok"
GET  /hello         → 200 "hello from turboAPI driving nanoapi runtime"
POST /echo-method   → 200 "method=POST"
GET  /missing       → 404 "not found"
\`\`\`

This is the exact shape turboAPI's Python FFI dispatcher will take — \`SpikeContext\` becomes a Python-interpreter pointer, the dispatch body becomes the existing handler-tuple machinery + the streaming SSE path from turboAPI [#164](https://github.com/justrach/turboAPI/pull/164).

## Out of scope

- Kqueue-only \`Connection\` struct still has \`server: *Server\` — fine, since \`*Server\` now has \`.dispatcher\` instead of \`.app\`.
- The \`pre-rendered static-response cache\` is still owned by \`App.router\` — non-App dispatchers leave \`try_static_dispatch = null\` to skip it. A follow-up could expose a generic static-response cache primitive in \`server.zig\` if other consumers want the optimization.
- WebSocket upgrade path — separate concern, tracked in turboAPI [#114](https://github.com/justrach/turboAPI/issues/114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)